### PR TITLE
取得可能なコモンイベント情報の増大と設定機能の有効化

### DIFF
--- a/AppMesOpp.cs
+++ b/AppMesOpp.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+
+namespace WolfEventCodeCreater
+{
+	public static class AppMesOpp
+	{
+		private static List<string> appMesList;
+		private static string appMes;
+
+		/// <summary>
+		/// このアプリのメッセージ画面に出力する文字列
+		/// </summary>
+		public static string AppMes
+		{
+			get
+			{
+				appMes = "";
+				appMesList.ForEach(x => appMes = appMes + x);
+				return appMes;
+			}
+		}
+
+		static AppMesOpp()
+		{
+			appMesList = new List<string>();
+		}
+
+		///<summary>
+		///アプリのメッセージを追加設定する
+		///</summary>
+		public static void SetAppMessge(string message)
+		{
+			appMesList.Add(message);
+		}
+	}
+}

--- a/AppMesOpp.cs
+++ b/AppMesOpp.cs
@@ -1,36 +1,62 @@
 ﻿using System.Collections.Generic;
+using System.Windows.Forms;
 
 namespace WolfEventCodeCreater
 {
 	public static class AppMesOpp
 	{
-		private static List<string> appMesList;
-		private static string appMes;
+		private const string APP_MES_SEPARATOR = "--------------------------------\r\n\r\n";
 
-		/// <summary>
-		/// このアプリのメッセージ画面に出力する文字列
-		/// </summary>
-		public static string AppMes
-		{
-			get
-			{
-				appMes = "";
-				appMesList.ForEach(x => appMes = appMes + x);
-				return appMes;
-			}
-		}
+		private static List<string> appMesList;
 
 		static AppMesOpp()
 		{
 			appMesList = new List<string>();
 		}
 
+		///<summary>セパレーター</summary>
+		public static string AppMesSeparator
+		{
+			get { return APP_MES_SEPARATOR; }
+		}
+
 		///<summary>
 		///アプリのメッセージを追加設定する
 		///</summary>
-		public static void SetAppMessge(string message)
+		public static void AddAppMessge(string message)
 		{
 			appMesList.Add(message);
+		}
+
+		///<summary>
+		///アプリの区切りメッセージを追加設定する
+		///</summary>
+		public static void AddSeparatorAppMessge()
+		{
+			appMesList.Add(APP_MES_SEPARATOR);
+		}
+
+		///<summary>
+		///アプリのメッセージを返す
+		///</summary>
+		public static string ReturnAppMessge(bool isClearAppMessList = true)
+		{
+			string appMes = "";
+			appMesList.ForEach(x => appMes = appMes + "\r\n" + x);
+
+			if (isClearAppMessList)
+			{
+				appMesList.Clear();
+			}
+			return appMes;
+		}
+
+		///<summary>
+		///アプリのメッセージをクリアする
+		///</summary>
+		public static void ClearAppMessge()
+		{
+			appMesList.Clear();
 		}
 	}
 }

--- a/AppMesOpp.cs
+++ b/AppMesOpp.cs
@@ -5,7 +5,7 @@ namespace WolfEventCodeCreater
 {
 	public static class AppMesOpp
 	{
-		private const string APP_MES_SEPARATOR = "--------------------------------\r\n\r\n";
+		private const string APP_MES_SEPARATOR = "------------------------------------\r\n\r\n";
 
 		private static List<string> appMesList;
 

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -6,6 +6,7 @@ using WodiKs.Ev.Common;
 using WodiKs.IO;
 using WolfEventCodeCreater.StrFormat;
 using WodiKs.Ev;
+using WolfEventCodeCreater.Model;
 
 namespace WolfEventCodeCreater
 {
@@ -56,7 +57,7 @@ namespace WolfEventCodeCreater
                 var commonName = Utils.String.Trim(CommonEvent.CommonEventName);
 
 				// コマンド数2未満、あるいはコモン名の入力がないもの、コメントアウトのものは除外
-                if (CommonEvent.NumEventCommand < 2 || commonName == "" || commonName.IndexOf(Config.CommentOut_Common) == 1)
+                if (CommonEvent.NumEventCommand < 2 || commonName == "" || commonName.IndexOf(Config.CommentOut) == 1)
                 {
                     continue;
                 }
@@ -123,7 +124,7 @@ namespace WolfEventCodeCreater
 							}
 							else
 							{
-								//!? InternalValueを取得できない（すべて0）。WodiKsライブラリのバグ？
+								//!? InternalValueを取得できない（すべて0）。WodiKs ver0.40ライブラリのバグ
 								MdList = mf.FormatSimpleSentence(MdList ,
 									$"cself[{ x }] - {Utils.WodiKs.ConvertNumericSpecialSettingTypeToName(InputNumericData.SpecialSettingType.ManuallyGenerateBranch)}");
 								List<string> headerManuallyGenerateBranch = new List<string> {"InternalValue" , "Name"};
@@ -227,7 +228,13 @@ namespace WolfEventCodeCreater
                 count++;
             }
 
-            return $"{ count }件のMarkdownを出力しました。";
+			//TODO:WodiKs ver0.40 のDB読込バグが修正されるまで一旦実装を中止する
+			// DB出力(将来はコモンイベント出力もまとめる)
+			//OutputDriver outputDriver = new OutputDriver(Config);
+			//outputDriver.Output();
+
+
+			return $"{ count }件のコモンイベントMarkdownを出力しました。";
         }
 
 

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -54,8 +54,8 @@ namespace WolfEventCodeCreater
                 // コモン名のトリミング
                 var commonName = Utils.String.Trim(CommonEvent.CommonEventName);
 
-                // コマンド数2未満、あるいはコモン名の入力がないもの、コメントアウトのものは除外
-                if (CommonEvent.NumEventCommand < 2 || commonName == "" || commonName.IndexOf("//") == 1)
+				// コマンド数2未満、あるいはコモン名の入力がないもの、コメントアウトのものは除外
+                if (CommonEvent.NumEventCommand < 2 || commonName == "" || commonName.IndexOf(Config.CommentOut_Common) == 1)
                 {
                     continue;
                 }
@@ -167,7 +167,7 @@ namespace WolfEventCodeCreater
 					"Cself[20~39]" , "Name[20~39]" , "  　" ,
 					"Cself[40~59]" , "Name[40~59]" , "　  " ,
 					"Cself[60~79]" , "Name[60~79]" , "　　" ,
-					"Cself[80~99]" , "Name[80~99]" };
+					"Cself[80~99]" , "Name[80~99]" };			// DataTable型のColumsの名前は重複不可
 				List<List<string>> dataCSelf = new List<List<string>>() { };
 				dataCSelf = PushCommonSelfNames(dataCSelf , CommonEvent);
 				MdList = mf.FormatTable(MdList , headerCSelf , dataCSelf , "CSelf");
@@ -291,13 +291,13 @@ namespace WolfEventCodeCreater
 
 
 
-        /// <summary>
-        /// コモンイベントをListに追加して戻す
-        /// </summary>
-        /// <param name="eventCode"></param>
-        /// <param name="CommonEvent"></param>
-        /// <returns></returns>
-        private List<string> PushEventCode(List<string> list, CommonEvent commonEvent)
+		/// <summary>
+		/// コモンイベントをListに追加して戻す
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="CommonEvent"></param>
+		/// <returns></returns>
+		private List<string> PushEventCode(List<string> list, CommonEvent commonEvent)
         {
             list.Add("WoditorEvCOMMAND_START");
 

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -64,11 +64,11 @@ namespace WolfEventCodeCreater
                 }
 
 				// ファイル名にコモン番号を付ける設定対応
+				string commonIDNo = System.String.Format("{0:000}" , commonID);
 				string fileName = commonName;
 				if (Config.IsOutputCommonNumber)
 				{
-					string fileNamePrefix = System.String.Format("{0:000}" , commonID);
-					fileName = $"{ fileNamePrefix }_{ commonName }";
+					fileName = $"{ commonIDNo }_{ commonName }";
 				}
 				var filepath = Path.Combine(Config.DumpDirPath, $"{ Utils.String.FormatFilename(fileName) }.common.md");
 
@@ -77,6 +77,10 @@ namespace WolfEventCodeCreater
 
 				MdList = mf.FormatHeadline(MdList , commonName , 1);
 				MdList = mf.FormatSimpleSentence(MdList , Utils.String.Trim(CommonEvent.Memo));
+
+				// コモン番号
+				MdList = mf.FormatHeadline(MdList , "コモン番号" , 2);
+				MdList = mf.FormatSimpleSentence(MdList , commonIDNo);
 
 				// コモンイベント色
 				MdList = mf.FormatHeadline(MdList , "コモンイベント色" , 2);

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -87,6 +87,22 @@ namespace WolfEventCodeCreater
                     MdList.Add("");
                 }
 
+				// 返り値
+				MdList.Add("## 返り値\n");
+				int returnVar = CommonEvent.Config.ReturnVariable;
+				if (returnVar == -1)
+				{
+					MdList.Add($"結果を返さない\n");
+				}
+				else
+				{
+					var returnValueName = Utils.String.Trim(CommonEvent.Config.ReturnValueName);
+					var cselfVal = returnVar % 100;
+					MdList.Add(" Name | Var ");
+					MdList.Add("--- | --- ");
+					MdList.Add($"{ returnValueName } | \\cself[{ cselfVal.ToString() }]");
+				}
+
 				// イベントコード
 				MdList.Add("## イベントコード\n");
 				MdList.Add("```");

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -33,11 +33,12 @@ namespace WolfEventCodeCreater
         /// Markdownファイルの出力
         /// </summary>
         /// <returns></returns>
-        public string Write()
+        public void Write()
         {
             if (CommonEventManager == null)
             {
-                return "ファイルがみつからない、あるいは使用中のため出力に失敗しました。";
+                AppMesOpp.AddAppMessge("ファイルがみつからない、あるいは使用中のため出力に失敗しました。");
+				return;
             }
 
             // ファイル出力するディレクトリの作成
@@ -234,7 +235,8 @@ namespace WolfEventCodeCreater
 			//outputDriver.Output();
 
 
-			return $"{ count }件のコモンイベントMarkdownを出力しました。";
+			AppMesOpp.AddAppMessge($"{ count }件のコモンイベントMarkdownを出力しました。");
+			return;
         }
 
 

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -65,19 +65,31 @@ namespace WolfEventCodeCreater
                 MdList.Add($"# { commonName }\n");
                 MdList.Add($"{ Utils.String.Trim(CommonEvent.Memo) }\n");
 
-                if (CommonEvent.NumInputNumeric + CommonEvent.NumInputString > 0)
+				// コモンイベント色
+				MdList.Add("## コモンイベント色\n");
+				MdList.Add($"{ Utils.WodiKs.ConvertCommonEventColorToName(CommonEvent.Color) }\n");
+
+				// 起動条件
+				MdList.Add("## 起動条件\n");
+				MdList.Add(" Type | Var | ComparisonValue | ComparisonMethod ");
+				MdList.Add("--- | --- | --- | --- ");
+				MdList = PushTriggerConditions(MdList , CommonEvent);
+				MdList.Add("");
+
+				// 引数
+				if (CommonEvent.NumInputNumeric + CommonEvent.NumInputString > 0)
                 {
-                    MdList.Add("## 引数\n");
-                    MdList.Add(" Type | Var | InitialValue | Name ");
+					MdList.Add("## 引数\n");
+					MdList.Add(" Type | Var | InitialValue | Name ");
                     MdList.Add("--- | --- | --- | --- ");
                     MdList = PushNumericConfig(MdList, CommonEvent);
                     MdList = PushStringConfig(MdList, CommonEvent);
                     MdList.Add("");
                 }
-                
-                // イベントコード
-                MdList.Add("## イベントコード\n");
-                MdList.Add("```");
+
+				// イベントコード
+				MdList.Add("## イベントコード\n");
+				MdList.Add("```");
                 MdList = PushEventCode(MdList, CommonEvent);
                 MdList.Add("```");
 
@@ -91,19 +103,39 @@ namespace WolfEventCodeCreater
 
 
 
-        /// <summary>
-        /// 数値の引数データをListに追加して戻す
-        /// </summary>
-        /// <param name="list"></param>
-        /// <param name="CommonEvent"></param>
-        /// <returns></returns>
-        private List<string> PushNumericConfig(List<string> list, CommonEvent commonEvent)
+		/// <summary>
+		/// 起動条件データをListに追加して戻す
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="CommonEvent"></param>
+		/// <returns></returns>
+		private List<string> PushTriggerConditions(List<string> list , CommonEvent commonEvent) {
+				
+			var triggerConditionsType = Utils.WodiKs.ConvertTriggerConditionsToName(commonEvent.TriggerConditionsType);
+			var triggerVariable = commonEvent.TriggerVariable.ToString();
+			var comparisonValue = commonEvent.ComparisonValue.ToString();
+			var comparisonMethodType = Utils.WodiKs.ConvertComparisonMethodToName(commonEvent.ComparisonMethodType);
+
+			list.Add($"{ triggerConditionsType } | { triggerVariable } | { comparisonValue } | { comparisonMethodType }");
+
+			return list;
+		}
+
+
+
+		/// <summary>
+		/// 数値の引数データをListに追加して戻す
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="CommonEvent"></param>
+		/// <returns></returns>
+		private List<string> PushNumericConfig(List<string> list, CommonEvent commonEvent)
         {
             var commonEventConfig = commonEvent.Config;
 
             for (int i = 0; i < commonEvent.NumInputNumeric; i++)
             {
-                var inputNumericData =  commonEventConfig.InputNumerics[i];
+                var inputNumericData = commonEventConfig.InputNumerics[i];
                 var initialValue = inputNumericData.InitialValue.ToString();
                 var name = Utils.String.Trim(inputNumericData.Name);
 
@@ -159,5 +191,19 @@ namespace WolfEventCodeCreater
 
             return list;
         }
-    }
+
+
+		/* 現在は未使用
+		/// <summary>
+		/// テキスト出力用の文字列に整形する
+		/// </summary>
+		/// <param name="entryName"></param>
+		/// <param name="data"></param>
+		/// <returns></returns>
+		private string FormatOutputTxtStr(string entryName , string data)
+		{
+			return $"## { entryName } :{ data }";
+		}
+		*/
+	}
 }

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -40,12 +40,12 @@ namespace WolfEventCodeCreater
             }
 
             // ファイル出力するディレクトリの作成
-            if (!Directory.Exists(Config.DumpDir))
+            if (!Directory.Exists(Config.DumpDirPath))
             {
-                Directory.CreateDirectory(Config.DumpDir);
+                Directory.CreateDirectory(Config.DumpDirPath);
             }
 
-            Console.WriteLine(Config.DumpDir);
+            Console.WriteLine(Config.DumpDirPath);
 
             int count = 0;
             for (int i = 0; i < CommonEventManager.NumCommonEvent; i++)
@@ -61,7 +61,7 @@ namespace WolfEventCodeCreater
                     continue;
                 }
 
-                var filepath = Path.Combine(Config.DumpDir, $"{ Utils.String.FormatFilename(commonName) }.common.md");
+                var filepath = Path.Combine(Config.DumpDirPath, $"{ Utils.String.FormatFilename(commonName) }.common.md");
 
                 MdList = new List<string>();
 				MdFormat mf = new MdFormat();

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -348,7 +348,13 @@ namespace WolfEventCodeCreater
             {
                 var eventCommand = commonEvent.EventCommandList[i];
 
-                list.Add(eventCommand.GetEventCode());
+				string eventCode = eventCommand.GetEventCode();
+
+				// コモンイベントコードを出力用に最適化
+				eventCode = Utils.String.RemoveDoubleCRCode(eventCode);
+				eventCode = Utils.String.EncloseCRLFCodeOrSimpleLFCodeInLtAndGt(eventCode);
+
+				list.Add(eventCode);
 
 				// 動作指定コマンドである行を取得
 				if (eventCommand.IsMoveEvent)

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -50,20 +50,27 @@ namespace WolfEventCodeCreater
             Console.WriteLine(Config.DumpDirPath);
 
             int count = 0;
-            for (int i = 0; i < CommonEventManager.NumCommonEvent; i++)
+            for (int commonID = 0; commonID < CommonEventManager.NumCommonEvent; commonID++)
             {
-                var CommonEvent = CommonEventManager.CommonEvents[i];
+                var CommonEvent = CommonEventManager.CommonEvents[commonID];
 
                 // コモン名のトリミング
                 var commonName = Utils.String.Trim(CommonEvent.CommonEventName);
 
 				// コマンド数2未満、あるいはコモン名の入力がないもの、コメントアウトのものは除外
-                if (CommonEvent.NumEventCommand < 2 || commonName == "" || commonName.IndexOf(Config.CommentOut) == 1)
+                if (CommonEvent.NumEventCommand < 2 || commonName == "" || commonName.IndexOf(Config.CommentOut) == 0)
                 {
                     continue;
                 }
 
-                var filepath = Path.Combine(Config.DumpDirPath, $"{ Utils.String.FormatFilename(commonName) }.common.md");
+				// ファイル名にコモン番号を付ける設定対応
+				string fileName = commonName;
+				if (Config.IsOutputCommonNumber)
+				{
+					string fileNamePrefix = System.String.Format("{0:000}" , commonID);
+					fileName = $"{ fileNamePrefix }_{ commonName }";
+				}
+				var filepath = Path.Combine(Config.DumpDirPath, $"{ Utils.String.FormatFilename(fileName) }.common.md");
 
                 MdList = new List<string>();
 				MdFormat mf = new MdFormat();

--- a/CodeCreater.cs
+++ b/CodeCreater.cs
@@ -107,6 +107,19 @@ namespace WolfEventCodeCreater
 					MdList = mf.FormatTable(MdList , headerReturn , dataReturn , "Return");
 				}
 
+				// コモンセルフ変数
+				MdList = mf.FormatHeadline(MdList , "コモンセルフ変数" , 2);
+
+				List<string> headerCSelf = new List<string>() {
+					"Cself[0~19]" , "Name[0~19]" , "    ",
+					"Cself[20~39]" , "Name[20~39]" , "  　" ,
+					"Cself[40~59]" , "Name[40~59]" , "　  " ,
+					"Cself[60~79]" , "Name[60~79]" , "　　" ,
+					"Cself[80~99]" , "Name[80~99]" };
+				List<List<string>> dataCSelf = new List<List<string>>() { };
+				dataCSelf = PushCommonSelfNames(dataCSelf , CommonEvent);
+				MdList = mf.FormatTable(MdList , headerCSelf , dataCSelf , "CSelf");
+
 				// イベントコード
 				MdList = mf.FormatHeadline(MdList , "イベントコード" , 2);
 				MdList.Add("```");
@@ -191,6 +204,34 @@ namespace WolfEventCodeCreater
 
             return list;
         }
+
+
+
+		/// <summary>
+		/// コモンセルフ変数名データをListに追加して戻す
+		/// </summary>
+		/// <param name="list"></param>
+		/// <param name="CommonEvent"></param>
+		/// <returns></returns>
+		private List<List<string>> PushCommonSelfNames(List<List<string>> list , CommonEvent commonEvent)
+		{
+			string separator = "";
+			int divideNum = commonEvent.CommonSelfNames.Length / 5;
+
+			for (int i = 0; i < divideNum; i++)
+			{
+				List<string> recordCommonSelfNames = new List<string>() {
+					$"cself[{(divideNum * 0 + i).ToString() }]", Utils.String.Trim(commonEvent.CommonSelfNames[divideNum * 0 + i]), separator ,
+					$"cself[{(divideNum * 1 + i).ToString() }]", Utils.String.Trim(commonEvent.CommonSelfNames[divideNum * 1 + i]), separator ,
+					$"cself[{(divideNum * 2 + i).ToString() }]", Utils.String.Trim(commonEvent.CommonSelfNames[divideNum * 2 + i]), separator ,
+					$"cself[{(divideNum * 3 + i).ToString() }]", Utils.String.Trim(commonEvent.CommonSelfNames[divideNum * 3 + i]), separator ,
+					$"cself[{(divideNum * 4 + i).ToString() }]", Utils.String.Trim(commonEvent.CommonSelfNames[divideNum * 4 + i])};
+
+				list.Add(recordCommonSelfNames);
+			}
+
+			return list;
+		}
 
 
 

--- a/MainWindow.Designer.cs
+++ b/MainWindow.Designer.cs
@@ -28,152 +28,152 @@
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
-            this.button1 = new System.Windows.Forms.Button();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.ファイルToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ヘルプToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.設定ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.button2 = new System.Windows.Forms.Button();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.menuStrip1.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // button1
-            // 
-            this.button1.Location = new System.Drawing.Point(173, 34);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(107, 23);
-            this.button1.TabIndex = 0;
-            this.button1.Text = "プロジェクト選択";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.selectProject);
-            // 
-            // textBox1
-            // 
-            this.textBox1.Location = new System.Drawing.Point(13, 36);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(154, 19);
-            this.textBox1.TabIndex = 1;
-            this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
-            // 
-            // label2
-            // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(14, 69);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(0, 12);
-            this.label2.TabIndex = 3;
-            // 
-            // menuStrip1
-            // 
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
+			this.button1 = new System.Windows.Forms.Button();
+			this.textBox1 = new System.Windows.Forms.TextBox();
+			this.label2 = new System.Windows.Forms.Label();
+			this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+			this.ファイルToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.selectProjectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.closeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ヘルプToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.設定ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.aboutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.button2 = new System.Windows.Forms.Button();
+			this.textBox2 = new System.Windows.Forms.TextBox();
+			this.menuStrip1.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// button1
+			// 
+			this.button1.Location = new System.Drawing.Point(173, 34);
+			this.button1.Name = "button1";
+			this.button1.Size = new System.Drawing.Size(107, 23);
+			this.button1.TabIndex = 0;
+			this.button1.Text = "プロジェクト選択";
+			this.button1.UseVisualStyleBackColor = true;
+			this.button1.Click += new System.EventHandler(this.selectProject);
+			// 
+			// textBox1
+			// 
+			this.textBox1.Location = new System.Drawing.Point(13, 36);
+			this.textBox1.Name = "textBox1";
+			this.textBox1.Size = new System.Drawing.Size(154, 19);
+			this.textBox1.TabIndex = 1;
+			this.textBox1.TextChanged += new System.EventHandler(this.textBox1_TextChanged);
+			// 
+			// label2
+			// 
+			this.label2.AutoSize = true;
+			this.label2.Location = new System.Drawing.Point(14, 69);
+			this.label2.Name = "label2";
+			this.label2.Size = new System.Drawing.Size(0, 12);
+			this.label2.TabIndex = 3;
+			// 
+			// menuStrip1
+			// 
+			this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.ファイルToolStripMenuItem,
             this.ヘルプToolStripMenuItem});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(292, 24);
-            this.menuStrip1.TabIndex = 5;
-            this.menuStrip1.Text = "menuStrip1";
-            // 
-            // ファイルToolStripMenuItem
-            // 
-            this.ファイルToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+			this.menuStrip1.Name = "menuStrip1";
+			this.menuStrip1.Size = new System.Drawing.Size(292, 24);
+			this.menuStrip1.TabIndex = 5;
+			this.menuStrip1.Text = "menuStrip1";
+			// 
+			// ファイルToolStripMenuItem
+			// 
+			this.ファイルToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.selectProjectToolStripMenuItem,
             this.toolStripSeparator1,
             this.closeToolStripMenuItem});
-            this.ファイルToolStripMenuItem.Name = "ファイルToolStripMenuItem";
-            this.ファイルToolStripMenuItem.Size = new System.Drawing.Size(51, 20);
-            this.ファイルToolStripMenuItem.Text = "ファイル";
-            // 
-            // selectProjectToolStripMenuItem
-            // 
-            this.selectProjectToolStripMenuItem.Name = "selectProjectToolStripMenuItem";
-            this.selectProjectToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
-            this.selectProjectToolStripMenuItem.Text = "プロジェクト選択";
-            this.selectProjectToolStripMenuItem.Click += new System.EventHandler(this.selectProject);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(142, 6);
-            // 
-            // closeToolStripMenuItem
-            // 
-            this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
-            this.closeToolStripMenuItem.Text = "終了";
-            this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
-            // 
-            // ヘルプToolStripMenuItem
-            // 
-            this.ヘルプToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.ファイルToolStripMenuItem.Name = "ファイルToolStripMenuItem";
+			this.ファイルToolStripMenuItem.Size = new System.Drawing.Size(51, 20);
+			this.ファイルToolStripMenuItem.Text = "ファイル";
+			// 
+			// selectProjectToolStripMenuItem
+			// 
+			this.selectProjectToolStripMenuItem.Name = "selectProjectToolStripMenuItem";
+			this.selectProjectToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
+			this.selectProjectToolStripMenuItem.Text = "プロジェクト選択";
+			this.selectProjectToolStripMenuItem.Click += new System.EventHandler(this.selectProject);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.toolStripSeparator1.Size = new System.Drawing.Size(142, 6);
+			// 
+			// closeToolStripMenuItem
+			// 
+			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
+			this.closeToolStripMenuItem.Size = new System.Drawing.Size(145, 22);
+			this.closeToolStripMenuItem.Text = "終了";
+			this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
+			// 
+			// ヘルプToolStripMenuItem
+			// 
+			this.ヘルプToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.設定ToolStripMenuItem,
             this.aboutToolStripMenuItem});
-            this.ヘルプToolStripMenuItem.Name = "ヘルプToolStripMenuItem";
-            this.ヘルプToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
-            this.ヘルプToolStripMenuItem.Text = "ヘルプ";
-            // 
-            // 設定ToolStripMenuItem
-            // 
-            this.設定ToolStripMenuItem.Name = "設定ToolStripMenuItem";
-            this.設定ToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.設定ToolStripMenuItem.Text = "設定";
-            this.設定ToolStripMenuItem.Click += new System.EventHandler(this.setting);
-            // 
-            // aboutToolStripMenuItem
-            // 
-            this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
-            this.aboutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
-            this.aboutToolStripMenuItem.Text = "バージョン情報";
-            this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
-            // 
-            // button2
-            // 
-            this.button2.Enabled = false;
-            this.button2.Location = new System.Drawing.Point(12, 232);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(268, 29);
-            this.button2.TabIndex = 6;
-            this.button2.Text = "実行";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.create);
-            // 
-            // textBox2
-            // 
-            this.textBox2.Location = new System.Drawing.Point(12, 66);
-            this.textBox2.Multiline = true;
-            this.textBox2.Name = "textBox2";
-            this.textBox2.ReadOnly = true;
-            this.textBox2.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
-            this.textBox2.Size = new System.Drawing.Size(268, 157);
-            this.textBox2.TabIndex = 7;
-            // 
-            // MainWindow
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(292, 273);
-            this.Controls.Add(this.textBox2);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.textBox1);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.menuStrip1);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.menuStrip1;
-            this.Name = "MainWindow";
-            this.Text = "WolfEventCodeCreater";
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.ヘルプToolStripMenuItem.Name = "ヘルプToolStripMenuItem";
+			this.ヘルプToolStripMenuItem.Size = new System.Drawing.Size(46, 20);
+			this.ヘルプToolStripMenuItem.Text = "ヘルプ";
+			// 
+			// 設定ToolStripMenuItem
+			// 
+			this.設定ToolStripMenuItem.Name = "設定ToolStripMenuItem";
+			this.設定ToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+			this.設定ToolStripMenuItem.Text = "設定";
+			this.設定ToolStripMenuItem.Click += new System.EventHandler(this.setting);
+			// 
+			// aboutToolStripMenuItem
+			// 
+			this.aboutToolStripMenuItem.Name = "aboutToolStripMenuItem";
+			this.aboutToolStripMenuItem.Size = new System.Drawing.Size(139, 22);
+			this.aboutToolStripMenuItem.Text = "バージョン情報";
+			this.aboutToolStripMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
+			// 
+			// button2
+			// 
+			this.button2.Enabled = false;
+			this.button2.Location = new System.Drawing.Point(12, 232);
+			this.button2.Name = "button2";
+			this.button2.Size = new System.Drawing.Size(268, 29);
+			this.button2.TabIndex = 6;
+			this.button2.Text = "実行";
+			this.button2.UseVisualStyleBackColor = true;
+			this.button2.Click += new System.EventHandler(this.create);
+			// 
+			// textBox2
+			// 
+			this.textBox2.Location = new System.Drawing.Point(12, 66);
+			this.textBox2.Multiline = true;
+			this.textBox2.Name = "textBox2";
+			this.textBox2.ReadOnly = true;
+			this.textBox2.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
+			this.textBox2.Size = new System.Drawing.Size(268, 157);
+			this.textBox2.TabIndex = 7;
+			// 
+			// MainWindow
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 12F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(292, 273);
+			this.Controls.Add(this.textBox2);
+			this.Controls.Add(this.button2);
+			this.Controls.Add(this.label2);
+			this.Controls.Add(this.textBox1);
+			this.Controls.Add(this.button1);
+			this.Controls.Add(this.menuStrip1);
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MainMenuStrip = this.menuStrip1;
+			this.Name = "MainWindow";
+			this.Text = "WolfEventCodeCreater";
+			this.menuStrip1.ResumeLayout(false);
+			this.menuStrip1.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -10,7 +10,7 @@ namespace WolfEventCodeCreater
 		private Model.UserSetting userSetting;
 		private Model.Config Config;
 
-        public MainWindow()
+		public MainWindow()
         {
             InitializeComponent();
 			userSetting = Utils.File.LoadUserSetting();
@@ -42,30 +42,34 @@ namespace WolfEventCodeCreater
         private void create(object sender, EventArgs e)
         {
 			string now = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-			string message = $"------出力実行({ now })------" + "\r\n";
-			System.Diagnostics.Debug.WriteLine(message);
+			string headMessage = ($"------出力実行({ now })------" + "\r\n");
+			AppMesOpp.AddAppMessge(headMessage);
+			System.Diagnostics.Debug.WriteLine(headMessage);
 
 			try
             {
 				userSetting.ProjectRoot = Config.ProjectRoot;
+				// settings.xmlの上書き
 				Utils.File.WriteUserSetting(userSetting);
+
+				Config = new Model.Config(userSetting);
 
 				var CommonEventReader = new CommonEventDatReader(Config.CommonEventPath);
 
                 var CodeCreater = new CodeCreater(Config, CommonEventReader);
 
-                var writeMessage = CodeCreater.Write();
-
-				message = message + writeMessage + "\r\n" + "--------------------------------" + "\r\n";
-
-				textBox2.Text = message + textBox2.Text;
-
+				// 出力処理
+				CodeCreater.Write();
             }
             catch(Exception err)
             {
-                textBox2.Text = message+ err.ToString() + "--------------------------------" + "\r\n" + textBox2.Text;
+				AppMesOpp.AddAppMessge(err.ToString());
             }
-        }
+
+			// メッセージの表示
+			AppMesOpp.AddSeparatorAppMessge();
+			textBox2.Text = AppMesOpp.ReturnAppMessge(true) + textBox2.Text;
+		}
 
 
 

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -41,6 +41,8 @@ namespace WolfEventCodeCreater
         
         private void create(object sender, EventArgs e)
         {
+			AppMesOpp.ClearAppMessge();
+
 			string now = DateTime.Now.ToString("yyyyMMdd_HHmmss");
 			string headMessage = ($"------出力実行({ now })------");
 			AppMesOpp.AddAppMessge(headMessage);

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -42,7 +42,7 @@ namespace WolfEventCodeCreater
         private void create(object sender, EventArgs e)
         {
 			string now = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-			string headMessage = ($"------出力実行({ now })------" + "\r\n");
+			string headMessage = ($"------出力実行({ now })------");
 			AppMesOpp.AddAppMessge(headMessage);
 			System.Diagnostics.Debug.WriteLine(headMessage);
 
@@ -65,6 +65,9 @@ namespace WolfEventCodeCreater
             {
 				AppMesOpp.AddAppMessge(err.ToString());
             }
+
+			// settings.xmlを出力先ディレクトリに出力
+			Utils.File.WriteUserSetting(userSetting, Config.DumpDirPath, $"_{ now }");
 
 			// メッセージの表示
 			AppMesOpp.AddSeparatorAppMessge();

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -7,12 +7,17 @@ namespace WolfEventCodeCreater
 {
     public partial class MainWindow : Form
     {
-        private Model.Config Config;
+		private Model.UserSetting userSetting;
+		private Model.Config Config;
 
         public MainWindow()
         {
             InitializeComponent();
-        }
+			userSetting = Utils.File.LoadUserSetting();
+			Config = new Model.Config(userSetting);
+
+			textBox1.Text = userSetting.ProjectRoot;
+		}
 
 
 
@@ -24,10 +29,11 @@ namespace WolfEventCodeCreater
 
             if (fbd.ShowDialog(this) == DialogResult.OK)
             {
-                Config = new Model.Config(fbd.SelectedPath, Utils.File.LoadUserSetting());
-
-                textBox1.Text = fbd.SelectedPath;
-                button2.Enabled = true;
+				textBox1.Text = fbd.SelectedPath;
+				if (!button2.Enabled)
+				{
+					textBox2.Text = "ウディタ定義ファイルが見つかりません。" + "\r\n" + textBox2.Text;
+				}
             }
         }
 
@@ -35,21 +41,29 @@ namespace WolfEventCodeCreater
         
         private void create(object sender, EventArgs e)
         {
-            try
-            {
-                var CommonEventReader = new CommonEventDatReader(Config.CommonEventPath);
+			string now = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+			string message = $"------出力実行({ now })------" + "\r\n";
+			System.Diagnostics.Debug.WriteLine(message);
 
+			try
+            {
+				userSetting.ProjectRoot = Config.ProjectRoot;
+				Utils.File.WriteUserSetting(userSetting);
+
+				var CommonEventReader = new CommonEventDatReader(Config.CommonEventPath);
 
                 var CodeCreater = new CodeCreater(Config, CommonEventReader);
 
-                var message = CodeCreater.Write();
-                
-                textBox2.Text = textBox2.Text == "" ? message : message + "\r\n" + textBox2.Text;
+                var writeMessage = CodeCreater.Write();
+
+				message = message + writeMessage + "\r\n" + "--------------------------------" + "\r\n";
+
+				textBox2.Text = message + textBox2.Text;
 
             }
             catch(Exception err)
             {
-                textBox2.Text = err.ToString();
+                textBox2.Text = message+ err.ToString() + "--------------------------------" + "\r\n" + textBox2.Text;
             }
         }
 
@@ -83,7 +97,9 @@ namespace WolfEventCodeCreater
 
         private void textBox1_TextChanged(object sender, EventArgs e)
         {
-            button2.Enabled = true;
+			Config.ProjectRoot = textBox1.Text;
+			Config.PathChangeWithRootChanged(userSetting);
+			button2.Enabled = Config.IsWoditerDefineFiles();
         }
-    }
+	}
 }

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -97,7 +97,7 @@ namespace WolfEventCodeCreater
 
         private void setting(object sender, EventArgs e)
         {
-            var settingWindow = new SettingWindow();
+            var settingWindow = new SettingWindow(userSetting);
             settingWindow.ShowDialog(this);
             settingWindow.Dispose();
         }

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -84,30 +84,72 @@ namespace WolfEventCodeCreater.Model
 
 
 
-		public Config(string root, UserSetting userSetting)
+		public Config(UserSetting userSetting)
         {
-			ProjectRoot =root;
+			ProjectRoot = userSetting.ProjectRoot;
 			System.Diagnostics.Debug.WriteLine(ProjectRoot , "ProjectRoot");
-			DumpDirPath = RootPathCombine(userSetting.OutputDirName);
-			CEvDumpDirPath = Path.Combine(DumpDirPath , "CEv");
-			CDBDumpDirPath = Path.Combine(DumpDirPath , "CDB");
-			UDBDumpDirPath = Path.Combine(DumpDirPath , "UDB");
-			SDBDumpDirPath = Path.Combine(DumpDirPath , "SDB");
-			CommonEventPath = RootPathCombine(userSetting.CommonEventPath);
-			CDBProjrctFilePath = RootPathCombine(userSetting.CDBProjrctFilePath);
-			CDBDatFilePath = RootPathCombine(userSetting.CDBDatFilePath);
-			UDBProjrctFilePath = RootPathCombine(userSetting.UDBProjrctFilePath);
-			UDBDatFilePath = RootPathCombine(userSetting.UDBDatFilePath);
-			SDBProjrctFilePath = RootPathCombine(userSetting.SDBProjrctFilePath);
-			SDBDatFilePath = RootPathCombine(userSetting.SDBDatFilePath);
+			PathChangeWithRootChanged(userSetting);
 
 			CommentOut = userSetting.CommentOut;
 
 			IsOutputCommonNumber = userSetting.IsOutputCommonNumber;
 		}
-		private string RootPathCombine(string path)
+
+		private string RootPathCombine(string path1, string path2)
 		{
-			return Path.Combine(ProjectRoot , path);
+			return Path.Combine(ProjectRoot , path1, path2);
+		}
+
+		///<summary>ルートパスに依存するパスの書き換え</summary>
+		public void PathChangeWithRootChanged(UserSetting userSetting) { 
+			DumpDirPath = RootPathCombine(userSetting.OutputDirName,"");
+			CEvDumpDirPath = Path.Combine(DumpDirPath, "CEv");
+			CDBDumpDirPath = Path.Combine(DumpDirPath, "CDB");
+			UDBDumpDirPath = Path.Combine(DumpDirPath, "UDB");
+			SDBDumpDirPath = Path.Combine(DumpDirPath, "SDB");
+			CommonEventPath = RootPathCombine(userSetting.CommonEventPath, "CommonEvent.dat");
+			CDBProjrctFilePath = RootPathCombine(userSetting.CDBProjrctFilePath, "CDataBase.project");
+			CDBDatFilePath = RootPathCombine(userSetting.CDBDatFilePath , "CDataBase.dat");
+			UDBProjrctFilePath = RootPathCombine(userSetting.UDBProjrctFilePath , "DataBase.project");
+			UDBDatFilePath = RootPathCombine(userSetting.UDBDatFilePath , "DataBase.dat");
+			SDBProjrctFilePath = RootPathCombine(userSetting.SDBProjrctFilePath , "SysDataBase.project");
+			SDBDatFilePath = RootPathCombine(userSetting.SDBDatFilePath , "SysDataBase.dat");
+		}
+
+		///<summary>ウディタの定義ファイルの存在を確認する</summary>
+		public bool IsWoditerDefineFiles()
+		{
+			bool tmpFlg = true;
+
+			if (!Utils.File.CheckFileExist(CommonEventPath , "コモンイベント定義ファイル"))
+			{
+				tmpFlg = false;
+			}
+			if (!Utils.File.CheckFileExist(CDBProjrctFilePath , "可変DB定義ファイル(project)"))
+			{
+				tmpFlg = false;
+			}
+			if (!Utils.File.CheckFileExist(CDBDatFilePath , "可変DB定義ファイル(dat)"))
+			{
+				tmpFlg = false;
+			}
+			if (!Utils.File.CheckFileExist(UDBProjrctFilePath , "ユーザーDB定義ファイル(project)"))
+			{
+				tmpFlg = false;
+			}
+			if (!Utils.File.CheckFileExist(UDBDatFilePath , "ユーザーDB定義ファイル(dat)"))
+			{
+				tmpFlg = false;
+			}
+			if (!Utils.File.CheckFileExist(SDBProjrctFilePath , "システムDB定義ファイル(project)"))
+			{
+				tmpFlg = false;
+			}
+			if (!Utils.File.CheckFileExist(SDBDatFilePath , "システムDB定義ファイル(dat)"))
+			{
+				tmpFlg = false;
+			}
+			return tmpFlg;
 		}
 	}
 }

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -7,21 +7,99 @@ namespace WolfEventCodeCreater.Model
 	/// </summary>
 	public class Config
     {
-        public string ProjectRoot;
-        public string DumpDir;
-        public string CommonEventPath;
+		/// <summary>
+		/// 対象ウディタのルートパス
+		/// </summary>
+		public string ProjectRoot;
+
+		/// <summary>
+		/// 出力するディレクトリへのフルパス
+		/// </summary>
+		public string DumpDirPath;
+
+		/// <summary>
+		/// コモンイベントを出力するディレクトリへのフルパス
+		/// </summary>
+		public string CEvDumpDirPath;
+
+		/// <summary>
+		/// CDBを出力するディレクトリへのフルパス
+		/// </summary>
+		public string CDBDumpDirPath;
+
+		/// <summary>
+		/// UDBを出力するディレクトリへのフルパス
+		/// </summary>
+		public string UDBDumpDirPath;
+
+		/// <summary>
+		/// SDBを出力するディレクトリへのフルパス
+		/// </summary>
+		public string SDBDumpDirPath;
+
+		/// <summary>
+		/// コモンイベントの定義ファイル(dat)へのフルパス
+		/// </summary>
+		public string CommonEventPath;
+
+		/// <summary>
+		/// 可変DBの定義ファイル(project)へのフルパス
+		/// </summary>
+		public string CDBProjrctFilePath;
+
+		/// <summary>
+		/// 可変DBの定義ファイル(dat)へのフルパス
+		/// </summary>
+		public string CDBDatFilePath;
+
+		/// <summary>
+		/// ユーザーDBの定義ファイル(project)へのフルパス
+		/// </summary>
+		public string UDBProjrctFilePath;
+
+		/// <summary>
+		/// ユーザーDBの定義ファイル(dat)へのフルパス
+		/// </summary>
+		public string UDBDatFilePath;
+
+		/// <summary>
+		/// システムDBの定義ファイル(project)へのフルパス
+		/// </summary>
+		public string SDBProjrctFilePath;
+
+		/// <summary>
+		/// システムDBの定義ファイル(dat)へのフルパス
+		/// </summary>
+		public string SDBDatFilePath;
+
+		/// <summary>
+		/// 出力しないコモンのコメントアウト形式へのフルパス
+		/// </summary>
 		public string CommentOut_Common;
 
 
 
         public Config(string root, UserSetting userSetting)
         {
-            ProjectRoot = root;
-            DumpDir = Path.Combine(root, Utils.String.FormatFilename(userSetting.OutputDirName));
-            CommonEventPath = Path.Combine(root, @"Data\BasicData\CommonEvent.dat");
-			CommentOut_Common = userSetting.CommentOut;
+			ProjectRoot = Utils.String.FormatFilename(root);
+			DumpDirPath = RootPathCombine(userSetting.OutputDirName);
+			CEvDumpDirPath = Path.Combine(DumpDirPath , "CEv");
+			CDBDumpDirPath = Path.Combine(DumpDirPath , "CDB");
+			UDBDumpDirPath = Path.Combine(DumpDirPath , "UDB");
+			SDBDumpDirPath = Path.Combine(DumpDirPath , "SDB");
+			CommonEventPath = RootPathCombine(userSetting.CommonEventPath);
+			CDBProjrctFilePath = RootPathCombine(userSetting.CDBProjrctFilePath);
+			CDBDatFilePath = RootPathCombine(userSetting.CDBDatFilePath);
+			UDBProjrctFilePath = RootPathCombine(userSetting.UDBProjrctFilePath);
+			UDBDatFilePath = RootPathCombine(userSetting.UDBDatFilePath);
+			SDBProjrctFilePath = RootPathCombine(userSetting.SDBProjrctFilePath);
+			SDBDatFilePath = RootPathCombine(userSetting.SDBDatFilePath);
+
 
 		}
-        
-    }
+		private string RootPathCombine(string path)
+		{
+			return Utils.String.FormatFilename(Path.Combine(ProjectRoot , path));
+		}
+	}
 }

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -117,35 +117,35 @@ namespace WolfEventCodeCreater.Model
 		}
 
 		///<summary>ウディタの定義ファイルの存在を確認する</summary>
-		public bool IsWoditerDefineFiles()
+		public bool IsWoditerDefineFiles(bool isAddAppMes = true)
 		{
 			bool tmpFlg = true;
 
-			if (!Utils.File.CheckFileExist(CommonEventPath , "コモンイベント定義ファイル"))
+			if (!Utils.File.CheckFileExist(CommonEventPath , isAddAppMes ? "コモンイベント定義ファイル" : ""))
 			{
 				tmpFlg = false;
 			}
-			if (!Utils.File.CheckFileExist(CDBProjrctFilePath , "可変DB定義ファイル(project)"))
+			if (!Utils.File.CheckFileExist(CDBProjrctFilePath , isAddAppMes ? "可変DB定義ファイル(project)" : ""))
 			{
 				tmpFlg = false;
 			}
-			if (!Utils.File.CheckFileExist(CDBDatFilePath , "可変DB定義ファイル(dat)"))
+			if (!Utils.File.CheckFileExist(CDBDatFilePath , isAddAppMes ? "可変DB定義ファイル(dat)" : ""))
 			{
 				tmpFlg = false;
 			}
-			if (!Utils.File.CheckFileExist(UDBProjrctFilePath , "ユーザーDB定義ファイル(project)"))
+			if (!Utils.File.CheckFileExist(UDBProjrctFilePath , isAddAppMes ? "ユーザーDB定義ファイル(project)" : ""))
 			{
 				tmpFlg = false;
 			}
-			if (!Utils.File.CheckFileExist(UDBDatFilePath , "ユーザーDB定義ファイル(dat)"))
+			if (!Utils.File.CheckFileExist(UDBDatFilePath , isAddAppMes ? "ユーザーDB定義ファイル(dat)" : ""))
 			{
 				tmpFlg = false;
 			}
-			if (!Utils.File.CheckFileExist(SDBProjrctFilePath , "システムDB定義ファイル(project)"))
+			if (!Utils.File.CheckFileExist(SDBProjrctFilePath , isAddAppMes ? "システムDB定義ファイル(project)" : ""))
 			{
 				tmpFlg = false;
 			}
-			if (!Utils.File.CheckFileExist(SDBDatFilePath , "システムDB定義ファイル(dat)"))
+			if (!Utils.File.CheckFileExist(SDBDatFilePath , isAddAppMes ? "システムDB定義ファイル(dat)" : ""))
 			{
 				tmpFlg = false;
 			}

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -73,9 +73,9 @@ namespace WolfEventCodeCreater.Model
 		public string SDBDatFilePath;
 
 		/// <summary>
-		/// 出力しないコモンのコメントアウト形式へのフルパス
+		/// 出力しないコメントアウト形式へのフルパス
 		/// </summary>
-		public string CommentOut_Common;
+		public string CommentOut;
 
 		/// <summary>
 		/// 出力のときファイル名にコモン番号をつけるかどうか
@@ -101,7 +101,7 @@ namespace WolfEventCodeCreater.Model
 			SDBProjrctFilePath = RootPathCombine(userSetting.SDBProjrctFilePath);
 			SDBDatFilePath = RootPathCombine(userSetting.SDBDatFilePath);
 
-			CommentOut_Common = userSetting.CommentOut;
+			CommentOut = userSetting.CommentOut;
 
 			IsOutputCommonNumber = userSetting.IsOutputCommonNumber;
 		}

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -77,11 +77,17 @@ namespace WolfEventCodeCreater.Model
 		/// </summary>
 		public string CommentOut_Common;
 
+		/// <summary>
+		/// 出力のときファイル名にコモン番号をつけるかどうか
+		/// </summary>
+		public bool IsOutputCommonNumber;
 
 
-        public Config(string root, UserSetting userSetting)
+
+		public Config(string root, UserSetting userSetting)
         {
-			ProjectRoot = Utils.String.FormatFilename(root);
+			ProjectRoot =root;
+			System.Diagnostics.Debug.WriteLine(ProjectRoot , "ProjectRoot");
 			DumpDirPath = RootPathCombine(userSetting.OutputDirName);
 			CEvDumpDirPath = Path.Combine(DumpDirPath , "CEv");
 			CDBDumpDirPath = Path.Combine(DumpDirPath , "CDB");
@@ -95,11 +101,13 @@ namespace WolfEventCodeCreater.Model
 			SDBProjrctFilePath = RootPathCombine(userSetting.SDBProjrctFilePath);
 			SDBDatFilePath = RootPathCombine(userSetting.SDBDatFilePath);
 
+			CommentOut_Common = userSetting.CommentOut;
 
+			IsOutputCommonNumber = userSetting.IsOutputCommonNumber;
 		}
 		private string RootPathCombine(string path)
 		{
-			return Utils.String.FormatFilename(Path.Combine(ProjectRoot , path));
+			return Path.Combine(ProjectRoot , path);
 		}
 	}
 }

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -149,6 +149,11 @@ namespace WolfEventCodeCreater.Model
 			{
 				tmpFlg = false;
 			}
+
+			if (tmpFlg)
+			{
+				System.Diagnostics.Debug.WriteLine("WoditerDefineFiles are All Exists");
+			}
 			return tmpFlg;
 		}
 	}

--- a/Model/Config.cs
+++ b/Model/Config.cs
@@ -2,14 +2,15 @@
 
 namespace WolfEventCodeCreater.Model
 {
-    /// <summary>
-    /// 設定関連
-    /// </summary>
-    public class Config
+	/// <summary>
+	/// UserSetting情報から読み込まれた設定関連
+	/// </summary>
+	public class Config
     {
         public string ProjectRoot;
         public string DumpDir;
         public string CommonEventPath;
+		public string CommentOut_Common;
 
 
 
@@ -18,7 +19,9 @@ namespace WolfEventCodeCreater.Model
             ProjectRoot = root;
             DumpDir = Path.Combine(root, Utils.String.FormatFilename(userSetting.OutputDirName));
             CommonEventPath = Path.Combine(root, @"Data\BasicData\CommonEvent.dat");
-        }
+			CommentOut_Common = userSetting.CommentOut;
+
+		}
         
     }
 }

--- a/Model/OutputDriver.cs
+++ b/Model/OutputDriver.cs
@@ -1,0 +1,165 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using WodiKs.DB;
+using WolfEventCodeCreater.Model.WoditerStr;
+using WolfEventCodeCreater.StrFormat;
+
+namespace WolfEventCodeCreater.Model
+{
+	public class OutputDriver
+	{
+		private Config config;
+		private WoditerInfo woditerInfo;
+		private WoditerInfoStr woditerInfoStr;
+
+		public  OutputDriver(Config config)
+		{
+			this.config = config;
+			woditerInfo = new WoditerInfo(config);
+			woditerInfoStr = new WoditerInfoStr(woditerInfo);
+		}
+
+		public void Output()
+		{
+			//if(CEvStrs != null)
+			CreateOutputStrsCEv();
+			if(woditerInfoStr.CDBStrs != null)
+			{
+				CreateOutputStrsDB(woditerInfoStr.CDBStrs , Database.DatabaseCategory.Changeable);
+			}
+			if (woditerInfoStr.UDBStrs != null)
+			{
+				CreateOutputStrsDB(woditerInfoStr.UDBStrs , Database.DatabaseCategory.User);
+			}
+			if (woditerInfoStr.SDBStrs != null)
+			{
+				CreateOutputStrsDB(woditerInfoStr.SDBStrs , Database.DatabaseCategory.System);
+			}
+		}
+
+		//TODO 実装
+		private void CreateOutputStrsCEv()
+		{
+		}
+
+		private void CreateOutputStrsDB(List<DatabaseTypeStr> databaseTypeStrs , Database.DatabaseCategory dbCategory)
+		{
+			MakeOutputDir(dbCategory);
+
+			foreach (DatabaseTypeStr databaseTypeStr in databaseTypeStrs)
+			{
+				// データ数0、あるいはタイプ名の入力がないもの、コメントアウトのものは除外
+				if (databaseTypeStr.TypeName.Sentence.IndexOf(config.CommentOut) == 1)
+				{
+					continue;
+				}
+
+				List<string> outputStrs = new List<string>() { };
+
+
+				
+			}
+		}
+
+		///<summary>出力先ディレクトリの存在確認（存在しない場合は新たに作成）</summary>
+		private void MakeOutputDir(Database.DatabaseCategory dbCategory)
+		{
+			string outputDir = "";
+			string appMesDirName = "";
+
+			switch (dbCategory)
+			{
+				case Database.DatabaseCategory.CommonEvent:
+					{
+						outputDir = config.CEvDumpDirPath;
+						appMesDirName = "コモンイベント出力フォルダ";
+						break;
+					}
+				case Database.DatabaseCategory.Changeable:
+					{
+						outputDir = config.CDBDumpDirPath;
+						appMesDirName = "可変DB出力フォルダ";
+						break;
+					}
+				case Database.DatabaseCategory.User:
+					{
+						outputDir = config.UDBDumpDirPath;
+						appMesDirName = "ユーザーDB出力フォルダ";
+						break;
+					}
+				case Database.DatabaseCategory.System:
+					{
+						outputDir = config.SDBDumpDirPath;
+						appMesDirName = "システムDB出力フォルダ";
+						break;
+					}
+			}
+			Utils.File.CheckDirectoryExist(outputDir , appMesDirName , true);
+		}
+
+
+
+		///<summary>出力ファイルパスに整形</summary>
+		private string ForamtToOutputFilePath(Database.DatabaseCategory dbCategory, string filenamePrefix)
+		{
+			string outputFilePath = "";
+			string filename = Utils.String.FormatFilename(filenamePrefix);
+
+			switch (dbCategory)
+			{
+				case Database.DatabaseCategory.CommonEvent:
+					{
+						outputFilePath = config.CEvDumpDirPath;
+						filename = ".common" + filename;
+						break;
+					}
+				case Database.DatabaseCategory.Changeable:
+					{
+						outputFilePath = config.CDBDumpDirPath;
+						filename = ".cdb" + filename;
+						break;
+					}
+				case Database.DatabaseCategory.User:
+					{
+						outputFilePath = config.UDBDumpDirPath;
+						filename = ".udb" + filename;
+						break;
+					}
+				case Database.DatabaseCategory.System:
+					{
+						outputFilePath = config.SDBDumpDirPath;
+						filename = ".sdb" + filename;
+						break;
+					}
+			}
+
+			filename = Utils.String.AddExtension(filename);
+
+			return outputFilePath = Path.Combine(outputFilePath , filename);
+		}
+
+
+
+		///<summary>DBの各内容をList&lt;string&gt;に整形して書き出し</summary>
+		private List<string> FormatDBContents(List<string> list, DatabaseTypeStr dts)
+		{
+			MdFormat format = new MdFormat();
+
+			/*    タイプIDとタイプ名    */
+			list = format.FormatHeadline(list, dts.TypeID.Sentence + ":" + dts.TypeName.Sentence , 1);
+
+			/*    メモ    */
+			list = format.FormatSimpleSentence(list , dts.Memo.Sentence);
+
+			/*    タイプの設定    */
+			list = format.FormatHeadline(list , dts.TypeConfig.EntryName , 2);
+			list = format.FormatTable(list , dts.TypeConfig.TableHeader , dts.TypeConfig.TableData);
+
+			//TODO:WodiKs ver0.40 のDB読込バグが修正されるまで一旦実装を中止する
+
+			return list;
+		}
+
+
+	}
+}

--- a/Model/OutputStruct/OutputStructBase.cs
+++ b/Model/OutputStruct/OutputStructBase.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WolfEventCodeCreater.Model.OutputStruct
+{
+	public enum OutputStructType { Sentence, Sentences, Table, Tables, Mix}
+
+	class OutputStructBase
+	{
+		///<summary>項目名</summary>
+		public string EntryName { get; private set; }
+
+		public OutputStructType StructType { get; private set; }
+
+		protected OutputStructBase(string entryName, OutputStructType outputStructTypeout)
+		{
+			EntryName = entryName;
+			StructType = outputStructTypeout;
+		}
+	}
+}

--- a/Model/OutputStruct/OutputStructBase.cs
+++ b/Model/OutputStruct/OutputStructBase.cs
@@ -8,14 +8,14 @@ namespace WolfEventCodeCreater.Model.OutputStruct
 {
 	public enum OutputStructType { Sentence, Sentences, Table, Tables, Mix}
 
-	class OutputStructBase
+	public class OutputStructBase
 	{
 		///<summary>項目名</summary>
 		public string EntryName { get; private set; }
 
 		public OutputStructType StructType { get; private set; }
 
-		protected OutputStructBase(string entryName, OutputStructType outputStructTypeout)
+		public OutputStructBase(string entryName, OutputStructType outputStructTypeout)
 		{
 			EntryName = entryName;
 			StructType = outputStructTypeout;

--- a/Model/OutputStruct/OutputStructSentence.cs
+++ b/Model/OutputStruct/OutputStructSentence.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WolfEventCodeCreater.Model.OutputStruct
+{
+	public class OutputStructSentence: OutputStructBase
+	{
+		///<summary>文章のデータ</summary>
+		public List<string> Sentences { get; private set; }
+
+		public OutputStructSentence(string entryName, List<string> sentences) 
+			:base(entryName, OutputStructType.Sentences)
+		{
+			Sentences = sentences;
+		}
+	}
+}

--- a/Model/OutputStruct/OutputStructSentence.cs
+++ b/Model/OutputStruct/OutputStructSentence.cs
@@ -6,15 +6,15 @@ using System.Threading.Tasks;
 
 namespace WolfEventCodeCreater.Model.OutputStruct
 {
-	public class OutputStructSentence: OutputStructBase
+	public class OutputStructSentence : OutputStructBase
 	{
 		///<summary>文章のデータ</summary>
-		public List<string> Sentences { get; private set; }
+		public string Sentence { get; private set; }
 
-		public OutputStructSentence(string entryName, List<string> sentences) 
-			:base(entryName, OutputStructType.Sentences)
+		public OutputStructSentence(string entryName , string sentence)
+			: base(entryName , OutputStructType.Sentence)
 		{
-			Sentences = sentences;
+			Sentence = sentence;
 		}
 	}
 }

--- a/Model/OutputStruct/OutputStructTable.cs
+++ b/Model/OutputStruct/OutputStructTable.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WolfEventCodeCreater.Model.OutputStruct
+{
+    public class OutputStructTable : OutputStructBase
+    {
+        ///<summary>表形式のヘッダ部</summary>
+        public List<string> TableHeader { get; private set; }
+
+        ///<summary>表形式のデータ部</summary>
+        public List<List<string>> TableData { get; private set; }
+
+        public OutputStructTable(string entryName, List<string> tableHeader, 
+            List<List<string>> tableData): base(entryName, OutputStructType.Table)
+        {
+            TableHeader = tableHeader;
+            TableData = tableData;
+        }
+    }
+}

--- a/Model/UserSetting.cs
+++ b/Model/UserSetting.cs
@@ -2,45 +2,50 @@
 {
     public class UserSetting
     {
-        /// <summary>
-        /// 出力するディレクトリ名
-        /// </summary>
-        public string OutputDirName = "Dump";
+		/// <summary>
+		/// ルートパス
+		/// </summary>
+		public string ProjectRoot = "";
+
+		/// <summary>
+		/// 出力するディレクトリ名
+		/// </summary>
+		public string OutputDirName = "Dump";
 
 		/// <summary>
 		/// コモンイベントの定義ファイル(dat)
 		/// </summary>
-		public string CommonEventPath = @"Data\BasicData\CommonEvent.dat";
+		public string CommonEventPath = @"Data\BasicData";
 
 		/// <summary>
 		/// 可変DBの定義ファイル(project)
 		/// </summary>
-		public string CDBProjrctFilePath = @"Data\BasicData\CDataBase.project";
+		public string CDBProjrctFilePath = @"Data\BasicData";
 
 		/// <summary>
 		/// 可変DBの定義ファイル(dat)
 		/// </summary>
-		public string CDBDatFilePath = @"Data\BasicData\CDataBase.dat";
+		public string CDBDatFilePath = @"Data\BasicData";
 
 		/// <summary>
 		/// ユーザーDBの定義ファイル(project)
 		/// </summary>
-		public string UDBProjrctFilePath = @"Data\BasicData\UDataBase.project";
+		public string UDBProjrctFilePath = @"Data\BasicData";
 
 		/// <summary>
 		/// ユーザーDBの定義ファイル(dat)
 		/// </summary>
-		public string UDBDatFilePath = @"Data\BasicData\UDataBase.dat";
+		public string UDBDatFilePath = @"Data\BasicData";
 
 		/// <summary>
 		/// システムDBの定義ファイル(project)
 		/// </summary>
-		public string SDBProjrctFilePath = @"Data\BasicData\SDataBase.project";
+		public string SDBProjrctFilePath = @"Data\BasicData";
 
 		/// <summary>
 		/// システムDBの定義ファイル(dat)
 		/// </summary>
-		public string SDBDatFilePath = @"Data\BasicData\SDataBase.dat";
+		public string SDBDatFilePath = @"Data\BasicData";
 
 		/// <summary>
 		/// 出力しないコモンのコメントアウト形式

--- a/Model/UserSetting.cs
+++ b/Model/UserSetting.cs
@@ -7,11 +7,46 @@
         /// </summary>
         public string OutputDirName = "Dump";
 
-        /// <summary>
-        /// 出力しないコモンのコメントアウト形式
-        /// </summary>
-        /// 
-        public string CommentOut = "//";
+		/// <summary>
+		/// コモンイベントの定義ファイル(dat)
+		/// </summary>
+		public string CommonEventPath = @"Data\BasicData\CommonEvent.dat";
+
+		/// <summary>
+		/// 可変DBの定義ファイル(project)
+		/// </summary>
+		public string CDBProjrctFilePath = @"Data/BasicData/CDataBase.project";
+
+		/// <summary>
+		/// 可変DBの定義ファイル(dat)
+		/// </summary>
+		public string CDBDatFilePath = @"/Data/BasicData/CDataBase.dat";
+
+		/// <summary>
+		/// ユーザーDBの定義ファイル(project)
+		/// </summary>
+		public string UDBProjrctFilePath = @"Data/BasicData/UDataBase.project";
+
+		/// <summary>
+		/// ユーザーDBの定義ファイル(dat)
+		/// </summary>
+		public string UDBDatFilePath = @"/Data/BasicData/UDataBase.dat";
+
+		/// <summary>
+		/// システムDBの定義ファイル(project)
+		/// </summary>
+		public string SDBProjrctFilePath = @"Data/BasicData/SDataBase.project";
+
+		/// <summary>
+		/// システムDBの定義ファイル(dat)
+		/// </summary>
+		public string SDBDatFilePath = @"/Data/BasicData/SDataBase.dat";
+
+		/// <summary>
+		/// 出力しないコモンのコメントアウト形式
+		/// </summary>
+		/// 
+		public string CommentOut = "//";
 
         /// <summary>
         /// 出力のときファイル名にコモン番号をつけるかどうか

--- a/Model/UserSetting.cs
+++ b/Model/UserSetting.cs
@@ -30,7 +30,7 @@
 		/// <summary>
 		/// ユーザーDBの定義ファイル(dat)
 		/// </summary>
-		public string UDBDatFilePath = @"\Data\BasicData\UDataBase.dat";
+		public string UDBDatFilePath = @"Data\BasicData\UDataBase.dat";
 
 		/// <summary>
 		/// システムDBの定義ファイル(project)
@@ -40,7 +40,7 @@
 		/// <summary>
 		/// システムDBの定義ファイル(dat)
 		/// </summary>
-		public string SDBDatFilePath = @"\Data\BasicData\SDataBase.dat";
+		public string SDBDatFilePath = @"Data\BasicData\SDataBase.dat";
 
 		/// <summary>
 		/// 出力しないコモンのコメントアウト形式

--- a/Model/UserSetting.cs
+++ b/Model/UserSetting.cs
@@ -15,32 +15,32 @@
 		/// <summary>
 		/// 可変DBの定義ファイル(project)
 		/// </summary>
-		public string CDBProjrctFilePath = @"Data/BasicData/CDataBase.project";
+		public string CDBProjrctFilePath = @"Data\BasicData\CDataBase.project";
 
 		/// <summary>
 		/// 可変DBの定義ファイル(dat)
 		/// </summary>
-		public string CDBDatFilePath = @"/Data/BasicData/CDataBase.dat";
+		public string CDBDatFilePath = @"Data\BasicData\CDataBase.dat";
 
 		/// <summary>
 		/// ユーザーDBの定義ファイル(project)
 		/// </summary>
-		public string UDBProjrctFilePath = @"Data/BasicData/UDataBase.project";
+		public string UDBProjrctFilePath = @"Data\BasicData\UDataBase.project";
 
 		/// <summary>
 		/// ユーザーDBの定義ファイル(dat)
 		/// </summary>
-		public string UDBDatFilePath = @"/Data/BasicData/UDataBase.dat";
+		public string UDBDatFilePath = @"\Data\BasicData\UDataBase.dat";
 
 		/// <summary>
 		/// システムDBの定義ファイル(project)
 		/// </summary>
-		public string SDBProjrctFilePath = @"Data/BasicData/SDataBase.project";
+		public string SDBProjrctFilePath = @"Data\BasicData\SDataBase.project";
 
 		/// <summary>
 		/// システムDBの定義ファイル(dat)
 		/// </summary>
-		public string SDBDatFilePath = @"/Data/BasicData/SDataBase.dat";
+		public string SDBDatFilePath = @"\Data\BasicData\SDataBase.dat";
 
 		/// <summary>
 		/// 出力しないコモンのコメントアウト形式

--- a/Model/WoditerInfo.cs
+++ b/Model/WoditerInfo.cs
@@ -1,0 +1,91 @@
+﻿using System.IO;
+using WodiKs.DB;
+using WodiKs.Ev.Common;
+using WodiKs.IO;
+
+namespace WolfEventCodeCreater.Model
+{
+	public class WoditerInfo
+	{
+		//private enum DBCategory { CDB, UDB, SDB }
+
+		public CommonEventManager CEvMgr { get; private set; }
+
+		public Database CDB { get; private set; }
+
+		public Database UDB { get; private set; }
+
+		public Database SDB { get; private set; }
+
+		public Config Config { get; private set; }
+
+		public WoditerInfo(Config config)
+		{
+			CDB = null;
+			UDB = null;
+			SDB = null;
+			this.Config = config;
+
+			CommonEventRead();
+			CDB = DatabaseRead(Database.DatabaseCategory.Changeable);
+			UDB = DatabaseRead(Database.DatabaseCategory.User);
+			SDB = DatabaseRead(Database.DatabaseCategory.System);
+		}
+
+		///<summary>DBを読込</summary>
+		///<param name="db">読込対象のDB</param>
+		private Database DatabaseRead(Database.DatabaseCategory dbCategory)
+		{
+			Database dbProperty = null;
+			string projectFilePath = "";
+			string datFilePath = "";
+			string dbName = "";
+			bool isProjectFileExist = false;
+			bool isDatFileExist = false;
+
+			switch (dbCategory)
+			{
+				case Database.DatabaseCategory.Changeable:
+					projectFilePath = Config.CDBProjrctFilePath;
+					datFilePath = Config.CDBDatFilePath;
+					dbName = "可変データベース";
+					break;
+				case Database.DatabaseCategory.User:
+					projectFilePath = Config.UDBProjrctFilePath;
+					datFilePath = Config.UDBDatFilePath;
+					dbName = "ユーザーデータベース";
+					break;
+				case Database.DatabaseCategory.System:
+					projectFilePath = Config.SDBProjrctFilePath;
+					datFilePath = Config.SDBDatFilePath;
+					dbName = "システムデータベース";
+					break;
+			}
+
+			// 定義ファイルの存在チェック
+			isProjectFileExist = Utils.File.CheckFileExist(Config.CDBDatFilePath , $"{ dbName }の定義ファイル(.project)");
+			isDatFileExist = Utils.File.CheckFileExist(Config.CDBDatFilePath , $"{ dbName }の定義ファイル(.dat)");
+
+			if (isProjectFileExist && isDatFileExist)
+			{
+				DatabaseFileReader dfr = new DatabaseFileReader(Config.CDBProjrctFilePath , Config.CDBProjrctFilePath);
+				dbProperty = dfr.GetReadData();
+			}
+
+			// DB読込エラー処理
+			if (dbProperty == null)
+			{
+				AppMesOpp.SetAppMessge($"{ dbName }の読込に失敗しました。");
+			}
+
+			return dbProperty;
+		}
+
+		//TODO:コモンイベント読み込み実装
+		///<summary>コモンイベントを読込</summary>
+		private void CommonEventRead()
+		{
+
+		}
+	}
+}

--- a/Model/WoditerInfo.cs
+++ b/Model/WoditerInfo.cs
@@ -96,7 +96,7 @@ namespace WolfEventCodeCreater.Model
 			// DB読込エラー処理
 			if (database == null)
 			{
-				AppMesOpp.SetAppMessge($"{ dbName }の読込に失敗しました。");
+				AppMesOpp.AddAppMessge($"{ dbName }の読込に失敗しました。");
 			}
 
 			return database;

--- a/Model/WoditerInfo.cs
+++ b/Model/WoditerInfo.cs
@@ -32,11 +32,18 @@ namespace WolfEventCodeCreater.Model
 			SDB = DatabaseRead(Database.DatabaseCategory.System);
 		}
 
+		//TODO:コモンイベント読み込み実装
+		///<summary>コモンイベントを読込</summary>
+		private void CommonEventRead()
+		{
+
+		}
+
 		///<summary>DBを読込</summary>
 		///<param name="db">読込対象のDB</param>
 		private Database DatabaseRead(Database.DatabaseCategory dbCategory)
 		{
-			Database dbProperty = null;
+			Database database = null;
 			string projectFilePath = "";
 			string datFilePath = "";
 			string dbName = "";
@@ -46,46 +53,54 @@ namespace WolfEventCodeCreater.Model
 			switch (dbCategory)
 			{
 				case Database.DatabaseCategory.Changeable:
+					{
 					projectFilePath = Config.CDBProjrctFilePath;
 					datFilePath = Config.CDBDatFilePath;
 					dbName = "可変データベース";
 					break;
+					}
 				case Database.DatabaseCategory.User:
+					{
 					projectFilePath = Config.UDBProjrctFilePath;
 					datFilePath = Config.UDBDatFilePath;
 					dbName = "ユーザーデータベース";
 					break;
+					}
 				case Database.DatabaseCategory.System:
+					{
 					projectFilePath = Config.SDBProjrctFilePath;
 					datFilePath = Config.SDBDatFilePath;
 					dbName = "システムデータベース";
 					break;
+					}
+				default:
+					{
+					// 念のため
+					break;
+					}
 			}
 
 			// 定義ファイルの存在チェック
-			isProjectFileExist = Utils.File.CheckFileExist(Config.CDBDatFilePath , $"{ dbName }の定義ファイル(.project)");
-			isDatFileExist = Utils.File.CheckFileExist(Config.CDBDatFilePath , $"{ dbName }の定義ファイル(.dat)");
+			isProjectFileExist = Utils.File.CheckFileExist(projectFilePath , $"{ dbName }の定義ファイル(.project)");
+			isDatFileExist = Utils.File.CheckFileExist(datFilePath , $"{ dbName }の定義ファイル(.dat)");
 
 			if (isProjectFileExist && isDatFileExist)
 			{
-				DatabaseFileReader dfr = new DatabaseFileReader(Config.CDBProjrctFilePath , Config.CDBProjrctFilePath);
-				dbProperty = dfr.GetReadData();
+				/* WodiKs.dll ver0.40にて以下のバグが発生
+				 * System.OverflowException: 算術演算の結果オーバーフローが発生しました。
+				*/
+				DatabaseFileReader dfr = new DatabaseFileReader(projectFilePath , datFilePath);
+				database = dfr.GetReadData();
 			}
 
 			// DB読込エラー処理
-			if (dbProperty == null)
+			if (database == null)
 			{
 				AppMesOpp.SetAppMessge($"{ dbName }の読込に失敗しました。");
 			}
 
-			return dbProperty;
+			return database;
 		}
 
-		//TODO:コモンイベント読み込み実装
-		///<summary>コモンイベントを読込</summary>
-		private void CommonEventRead()
-		{
-
-		}
 	}
 }

--- a/Model/WoditerStr/DatabaseDataIDStr.cs
+++ b/Model/WoditerStr/DatabaseDataIDStr.cs
@@ -11,15 +11,15 @@ namespace WolfEventCodeCreater.Model.WoditerStr
 {
 	public class DatabaseDataIDStr
 	{
-		public int DataID { get; private set; }
+		public OutputStructSentence DataID { get; private set; }
 		public OutputStructSentence DataName { get; private set; }
 		public List<DatabaseItemConfigStr> ItemConfigStrList { get; private set; }
 		public List<DatabaseItemStr> DataStrList { get; private set; }
 
 		public DatabaseDataIDStr(Data data, uint itemNum, int dataIdNo, ItemConfig itemConfig)
 		{
-			DataID = dataIdNo;
-			DataName = new OutputStructSentence("データ名" , new List<string>() { Utils.String.Trim(data.DataName) });
+			DataID = new OutputStructSentence("データID" ,  dataIdNo.ToString());
+			DataName = new OutputStructSentence("データ名" , Utils.String.Trim(data.DataName));
 			ItemConfigStrList = SetItemConfigStrList(itemConfig, itemNum);
 			DataStrList = SetItemStrList(data, itemNum, itemConfig, dataIdNo);
 		}

--- a/Model/WoditerStr/DatabaseDataIDStr.cs
+++ b/Model/WoditerStr/DatabaseDataIDStr.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WolfEventCodeCreater.Utils;
+using WolfEventCodeCreater.Model.OutputStruct;
+using WodiKs.DB;
+
+namespace WolfEventCodeCreater.Model.WoditerStr
+{
+	public class DatabaseDataIDStr
+	{
+		public int DataID { get; private set; }
+		public OutputStructSentence DataName { get; private set; }
+		public List<DatabaseItemConfigStr> ItemConfigStrList { get; private set; }
+		public List<DatabaseItemStr> DataStrList { get; private set; }
+
+		public DatabaseDataIDStr(Data data, uint itemNum, int dataIdNo, ItemConfig itemConfig)
+		{
+			DataID = dataIdNo;
+			DataName = new OutputStructSentence("データ名" , new List<string>() { Utils.String.Trim(data.DataName) });
+			ItemConfigStrList = SetItemConfigStrList(itemConfig, itemNum);
+			DataStrList = SetItemStrList(data, itemNum, itemConfig, dataIdNo);
+		}
+
+		private List<DatabaseItemConfigStr> SetItemConfigStrList(ItemConfig itemConfig, uint itemNum)
+		{
+			List<DatabaseItemConfigStr> itemConfigStrList = new List<DatabaseItemConfigStr>();
+
+			for (int itemNo = 0; itemNo < itemNum; itemNo++)
+			{
+				itemConfigStrList.Add(new DatabaseItemConfigStr(itemConfig, itemNo));
+			}
+
+			return itemConfigStrList;
+		}
+
+		private List<DatabaseItemStr> SetItemStrList(Data data, uint itemNum, ItemConfig itemConfig, int dataIdNo)
+		{
+			List<DatabaseItemStr> dataList = new List<DatabaseItemStr>() { };
+
+			for (int itemNo = 0; itemNo < itemNum; itemNo++)
+			{
+				dataList.Add(new DatabaseItemStr(data.ItemsData[itemNo], itemNo, itemConfig, dataIdNo));
+			}
+			return dataList;
+		}
+	}
+}

--- a/Model/WoditerStr/DatabaseItemConfigStr.cs
+++ b/Model/WoditerStr/DatabaseItemConfigStr.cs
@@ -10,14 +10,14 @@ namespace WolfEventCodeCreater.Model.WoditerStr
 {
 	public class DatabaseItemConfigStr
 	{
-		public int ItemIDNo { get; private set; }
+		public OutputStructSentence ItemID { get; private set; }
 		public OutputStructTable ItemConfigTable { get; private set; }
 		public OutputStructTable ItemConfigSubTable { get; private set; }
 
 
 		public DatabaseItemConfigStr(ItemConfig itemConfig , int itemIdNo)
 		{
-			ItemIDNo = itemIdNo;
+			ItemID = new OutputStructSentence("項目ID",  itemIdNo.ToString());
 			ItemConfigTable = SetItemConfigTable(itemConfig, itemIdNo);
 			ItemConfigSubTable = SetItemConfigSubTable(itemConfig);
 		}

--- a/Model/WoditerStr/DatabaseItemConfigStr.cs
+++ b/Model/WoditerStr/DatabaseItemConfigStr.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WolfEventCodeCreater.Model.OutputStruct;
+using WodiKs.DB;
+
+namespace WolfEventCodeCreater.Model.WoditerStr
+{
+	public class DatabaseItemConfigStr
+	{
+		public int ItemIDNo { get; private set; }
+		public OutputStructTable ItemConfigTable { get; private set; }
+		public OutputStructTable ItemConfigSubTable { get; private set; }
+
+
+		public DatabaseItemConfigStr(ItemConfig itemConfig , int itemIdNo)
+		{
+			ItemIDNo = itemIdNo;
+			ItemConfigTable = SetItemConfigTable(itemConfig, itemIdNo);
+			ItemConfigSubTable = SetItemConfigSubTable(itemConfig);
+		}
+
+		private OutputStructTable SetItemConfigTable(ItemConfig itemConfig, int itemIdNo)
+		{
+			return new OutputStructTable($"項目{itemIdNo.ToString()}の設定データ",
+				SetItemConfigTableHeader(itemConfig), SetItemConfigTableData(itemConfig));
+		}
+
+
+		private List<string> SetItemConfigTableHeader(ItemConfig itemConfig)
+		{
+			List<string> itemConfigTableHeader = new List<string>() {"ItemName",
+				"ItemDataType" ,"InitialValue","SpecialSettingType"};
+
+			return itemConfigTableHeader;
+		}
+
+		private List<List<string>> SetItemConfigTableData(ItemConfig itemConfig)
+		{
+			List<List<string>> itemConfigTableData = new List<List<string>>() { };
+
+			List<string> record = new List<string>() {Utils.String.Trim(itemConfig.ItemName),
+				Utils.WodiKs.ConvertItemTypeToName(itemConfig.ItemDataType),
+				itemConfig.InitialValue.ToString(),
+				Utils.WodiKs.ConvertItemConfigSpecialSettingTypeToName(itemConfig.SettingType)};
+
+			itemConfigTableData.Add(record);
+
+			return itemConfigTableData;
+		}
+
+		private OutputStructTable SetItemConfigSubTable(ItemConfig itemConfig)
+		{
+			return new OutputStructTable(
+				Utils.WodiKs.ConvertItemConfigSpecialSettingTypeToName(itemConfig.SettingType),
+				SetItemConfigSubTableHeader(itemConfig), SetItemConfigSubTableData(itemConfig));
+		}
+
+		private List<string> SetItemConfigSubTableHeader(ItemConfig itemConfig)
+		{
+			List<string> itemConfigSubTableHeader = new List<string>() { };
+
+			switch (itemConfig.SettingType)
+			{
+				case ItemConfig.SpecialSettingType.NotUse:
+					// No Operation
+					break;
+				case ItemConfig.SpecialSettingType.ReadFile:
+					itemConfigSubTableHeader.AddRange(new List<string>() { "フォルダパス", "保存時はフォルダ名を省くか" });
+					break;
+				case ItemConfig.SpecialSettingType.ReferenceDatabase:
+					itemConfigSubTableHeader.AddRange(new List<string>() { "DatabaseType", "TypeID", "AppendItemEnable", "-1", "-2", "-3" });
+					break;
+				case ItemConfig.SpecialSettingType.ManuallyGenerateBranch:
+					itemConfigSubTableHeader.AddRange(new List<string>() { "選択肢の内部値", "表示文字列" });
+					break;
+			}
+			return itemConfigSubTableHeader;
+		}
+
+		private List<List<string>> SetItemConfigSubTableData(ItemConfig itemConfig)
+		{
+			List<List<string>> itemConfigSubTableData = new List<List<string>>() { };
+
+			switch (itemConfig.SettingType)
+			{
+				case ItemConfig.SpecialSettingType.NotUse:
+					itemConfigSubTableData.Add(new List<string>() { });
+					break;
+				case ItemConfig.SpecialSettingType.ReadFile:
+					itemConfigSubTableData.Add(new List<string>() {
+						Utils.String.Trim(itemConfig.FolderPath), itemConfig.OmitFolderNameEnable.ToString() });
+					break;
+				case ItemConfig.SpecialSettingType.ReferenceDatabase:
+					itemConfigSubTableData.Add(new List<string>() {
+						Utils.WodiKs.ConvertDatabaseCategoryToName(itemConfig.DatabaseType),
+						itemConfig.TypeID.ToString(), itemConfig.AppendItemEnable.ToString(),
+						Utils.String.Trim(itemConfig.AppendItemNames[0]),
+						Utils.String.Trim(itemConfig.AppendItemNames[1]),
+						Utils.String.Trim(itemConfig.AppendItemNames[2])});
+					break;
+				case ItemConfig.SpecialSettingType.ManuallyGenerateBranch:
+					foreach(ItemConfigBranch branch in itemConfig.BranchData)
+					{
+						List<string> record = 
+							new List<string>() { branch.InternalValue.ToString(), Utils.String.Trim(branch.DisplayString) };
+						itemConfigSubTableData.Add(record);
+					}
+					break;
+			}
+			return itemConfigSubTableData;
+		}
+	}
+}

--- a/Model/WoditerStr/DatabaseItemStr.cs
+++ b/Model/WoditerStr/DatabaseItemStr.cs
@@ -10,14 +10,14 @@ namespace WolfEventCodeCreater.Model.WoditerStr
 {
 	public class DatabaseItemStr
 	{
-		public int DataNo { get; private set; }
-		public int ItemNo { get; private set; }
+		public OutputStructSentence DataID { get; private set; }
+		public OutputStructSentence ItemID { get; private set; }
 		public OutputStructTable DataTable { get; private set; }
 
 		public DatabaseItemStr(ItemData itemData, int itemIDNo, ItemConfig itemConfig, int dataIDNo)
 		{
-			DataNo = dataIDNo;
-			ItemNo = itemIDNo;
+			DataID = new OutputStructSentence("DataID", dataIDNo.ToString());
+			ItemID = new OutputStructSentence("項目ID" , itemIDNo.ToString());
 			DataTable = SetDataTable(itemData, itemIDNo, itemConfig);
 		}
 

--- a/Model/WoditerStr/DatabaseItemStr.cs
+++ b/Model/WoditerStr/DatabaseItemStr.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WolfEventCodeCreater.Model.OutputStruct;
+using WodiKs.DB;
+
+namespace WolfEventCodeCreater.Model.WoditerStr
+{
+	public class DatabaseItemStr
+	{
+		public int DataNo { get; private set; }
+		public int ItemNo { get; private set; }
+		public OutputStructTable DataTable { get; private set; }
+
+		public DatabaseItemStr(ItemData itemData, int itemIDNo, ItemConfig itemConfig, int dataIDNo)
+		{
+			DataNo = dataIDNo;
+			ItemNo = itemIDNo;
+			DataTable = SetDataTable(itemData, itemIDNo, itemConfig);
+		}
+
+		private OutputStructTable SetDataTable(ItemData itemData, int itemIDNo, ItemConfig itemConfig)
+		{
+			return new OutputStructTable($"項目{itemIDNo.ToString()}",
+				SetDataTableHeader(), SetDataTableData(itemData, itemConfig));
+		}
+
+
+		private List<string> SetDataTableHeader()
+		{
+			List<string> dataTableHeader = new List<string>() {
+				"ItemName","ValueType" ,"Value"};
+
+			return dataTableHeader;
+		}
+
+		private List<List<string>> SetDataTableData(ItemData itemData, ItemConfig itemConfig)
+		{
+			List<List<string>> dataTableData = new List<List<string>>() { };
+
+			List<string> record = new List<string>() { };
+
+
+			record.Add(Utils.String.Trim(itemConfig.ItemName));        // ItemName
+			record.Add(Utils.WodiKs.ConvertItemTypeToName(itemConfig.ItemDataType));    // ValueType
+
+			if (itemConfig.ItemDataType == ItemConfig.ItemType.Numeric)
+			{
+				record.Add(itemData.NumericData.ToString());        // Value
+			}
+			else
+			{
+				record.Add(Utils.String.Trim(itemData.StringData));        // Value
+			}
+
+			dataTableData.Add(record);
+
+			return dataTableData;
+		}
+	}
+}

--- a/Model/WoditerStr/DatabaseTypeStr.cs
+++ b/Model/WoditerStr/DatabaseTypeStr.cs
@@ -19,9 +19,9 @@ namespace WolfEventCodeCreater.Model.WoditerStr
 
 		public DatabaseTypeStr (WodiKs.DB.Type dbType , int typeID)
 		{
-			TypeID = new OutputStructSentence("タイプID" , new List<string>() { typeID.ToString() });
-			TypeName = new OutputStructSentence("タイプ名" , new List<string>() { Utils.String.Trim(dbType.TypeName) });
-			Memo = new OutputStructSentence("メモ" , new List<string>() { Utils.String.Trim(dbType.Memo) });
+			TypeID = new OutputStructSentence("タイプID" , typeID.ToString());
+			TypeName = new OutputStructSentence("タイプ名" , Utils.String.Trim(dbType.TypeName));
+			Memo = new OutputStructSentence("メモ" , Utils.String.Trim(dbType.Memo));
 			TypeConfig = new OutputStructTable("タイプ設定" , 
 				new List<string>() {"データIDの設定方法" , "指定DB" , "指定タイプID" } ,SetTypeConfigData(dbType));
 			SetTypeIDStr(dbType);

--- a/Model/WoditerStr/DatabaseTypeStr.cs
+++ b/Model/WoditerStr/DatabaseTypeStr.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WolfEventCodeCreater.Utils;
+using WolfEventCodeCreater.Model.OutputStruct;
+
+namespace WolfEventCodeCreater.Model.WoditerStr
+{
+	public class DatabaseTypeStr
+	{
+		public OutputStructSentence TypeID { get; private set; }
+		public OutputStructSentence TypeName { get; private set; }
+		public OutputStructSentence Memo { get; private set; }
+		public OutputStructTable TypeConfig { get; private set; }
+		public List<DatabaseItemConfigStr> ItemConfigList { get; private set; }
+		public List<DatabaseItemStr> DataList { get; private set; }
+
+		public DatabaseTypeStr (WodiKs.DB.Type dbType , int typeID)
+		{
+			TypeID = new OutputStructSentence("タイプID" , new List<string>() { typeID.ToString() });
+			TypeName = new OutputStructSentence("タイプ名" , new List<string>() { Utils.String.Trim(dbType.TypeName) });
+			Memo = new OutputStructSentence("メモ" , new List<string>() { Utils.String.Trim(dbType.Memo) });
+			TypeConfig = new OutputStructTable("タイプ設定" , 
+				new List<string>() {"データIDの設定方法" , "指定DB" , "指定タイプID" } ,SetTypeConfigData(dbType));
+			SetTypeIDStr(dbType);
+		}
+
+		private List<List<string>> SetTypeConfigData(WodiKs.DB.Type dbType)
+		{
+			List<List<string>> data = new List<List<string>>() { };
+
+			List<string> record = new List<string>() { };
+
+			WodiKs.DB.TypeConfig.SettingType settingType = dbType.TypeConfig.DataIDSetting;
+
+			record.Add(Utils.WodiKs.ConvertSettingTypeToName(settingType));
+
+			if(settingType == WodiKs.DB.TypeConfig.SettingType.DesiredDBType)
+			{
+				record.Add(Utils.WodiKs.ConvertDatabaseCategoryToName(dbType.TypeConfig.DesiredDBCategory));
+				record.Add(dbType.TypeConfig.DesiredTypeID.ToString());
+			}
+			else
+			{
+				record.Add("");
+				record.Add("");
+			}
+			
+			data.Add(record);
+			return data;
+		}
+
+		private List<DatabaseDataIDStr> SetTypeIDStr(WodiKs.DB.Type dbType)
+		{
+			List<DatabaseDataIDStr> typeIDStrList = new List<DatabaseDataIDStr>();
+
+			for (int dataIdNo = 0; dataIdNo < dbType.NumData; dataIdNo++)
+			{
+				typeIDStrList.Add(
+					new DatabaseDataIDStr(dbType.Data[dataIdNo], dbType.NumItems, dataIdNo, dbType.ItemsConfig[dataIdNo]));
+			}
+			return typeIDStrList;
+		}
+	}
+}

--- a/Model/WoditerStr/WoditerInfoStr.cs
+++ b/Model/WoditerStr/WoditerInfoStr.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WodiKs.DB;
+
+namespace WolfEventCodeCreater.Model.WoditerStr
+{
+	public class WoditerInfoStr
+	{
+		///<summary>文字列化したCommonEvent情報</summary>
+		//public List<CommonEvStr> CEvStrs{ get; private set; }
+
+		///<summary>文字列化したCDB情報</summary>
+		public List<DatabaseTypeStr> CDBStrs { get; private set; }
+
+		///<summary>文字列化したUDB情報</summary>
+		public List<DatabaseTypeStr> UDBStrs { get; private set; }
+		
+		///<summary>文字列化したSDB情報</summary>
+		public List<DatabaseTypeStr> SDBStrs { get; private set; }
+
+		public WoditerInfoStr(WoditerInfo woditerInfo)
+		{
+			if (woditerInfo == null)
+				return;
+
+			/*if (woditerInfo.CEvMgr != null)
+			{
+
+			}*/
+
+			if (woditerInfo.CDB != null)
+			{
+				CDBStrs = SetDBStrs(woditerInfo.CDB);
+			}
+
+			if (woditerInfo.UDB != null)
+			{
+				UDBStrs = SetDBStrs(woditerInfo.UDB);
+			}
+
+			if (woditerInfo.SDB != null)
+			{
+				SDBStrs = SetDBStrs(woditerInfo.SDB);
+			}
+		}
+
+		//private List<CommonEvStr> SetCEvStrs() { }
+
+		private List<DatabaseTypeStr> SetDBStrs(Database db)
+		{
+			List<DatabaseTypeStr> dBStrs = new List<DatabaseTypeStr>();
+
+			for(int typeIDNo = 0; typeIDNo < db.NumType; typeIDNo++)
+			{
+				dBStrs.Add(new DatabaseTypeStr(db.TypesData[typeIDNo] , typeIDNo));
+			}
+			return dBStrs;
+		}
+
+	}
+}

--- a/Model/WoditerStr/WoditerInfoStr.cs
+++ b/Model/WoditerStr/WoditerInfoStr.cs
@@ -55,6 +55,12 @@ namespace WolfEventCodeCreater.Model.WoditerStr
 
 			for(int typeIDNo = 0; typeIDNo < db.NumType; typeIDNo++)
 			{
+				// データ数0、あるいはタイプ名の入力がないものは除外
+				if (db.TypesData[typeIDNo].NumData == 0 || db.TypesData[typeIDNo].TypeName == "")
+				{
+					continue;
+				}
+
 				dBStrs.Add(new DatabaseTypeStr(db.TypesData[typeIDNo] , typeIDNo));
 			}
 			return dBStrs;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
 // 既定値にすることができます:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.0.0.0")]

--- a/SettingWindow.cs
+++ b/SettingWindow.cs
@@ -1,15 +1,18 @@
 ﻿using System;
 using System.Windows.Forms;
+using WolfEventCodeCreater.Model;
 
 namespace WolfEventCodeCreater
 {
     public partial class SettingWindow : Form
     {
-        public SettingWindow()
+		private UserSetting userSetting;
+
+		public SettingWindow(UserSetting userSetting)
         {
             InitializeComponent();
 
-            var userSetting = Utils.File.LoadUserSetting();
+            this.userSetting = userSetting;
 
             textBox1.Text = userSetting.OutputDirName;
             textBox2.Text = userSetting.CommentOut;
@@ -22,7 +25,6 @@ namespace WolfEventCodeCreater
 
         private void submit(object sender, EventArgs e)
         {
-            var userSetting = new Model.UserSetting();
             userSetting.OutputDirName = textBox1.Text;
             userSetting.CommentOut = textBox2.Text;
             userSetting.IsOutputCommonNumber = comboBox1.SelectedIndex == 0 ? true : false;

--- a/StrFormat/MdFormat.cs
+++ b/StrFormat/MdFormat.cs
@@ -56,6 +56,7 @@ namespace WolfEventCodeCreater.StrFormat
 		{
 			if (headerStrs == null || dataStrs == null)
 			{
+				System.Diagnostics.Debug.WriteLine("headerStrsまたはdataStrsがNull");
 				//TODO:Error処理
 				return mdList;
 			}
@@ -80,6 +81,7 @@ namespace WolfEventCodeCreater.StrFormat
 			}
 			else
 			{
+				System.Diagnostics.Debug.WriteLine("headerStrsまたはdataStrsの要素数が0、またはheaderStrsとdataStrsとの列数に差異がある");
 				//TODO:Error処理
 			}
 
@@ -121,7 +123,9 @@ namespace WolfEventCodeCreater.StrFormat
 			}
 			else
 			{
+				System.Diagnostics.Debug.WriteLine("headerStrsの要素数が0");
 				//TODO:Error処理
+				// このメソッドはprotectedかつ呼び出し元のFormatTableメソッドにてエラー処理しているため、Error処理不要だが一応残す
 			}
 			return mdList;
 		}

--- a/StrFormat/MdFormat.cs
+++ b/StrFormat/MdFormat.cs
@@ -1,0 +1,170 @@
+﻿using System.Collections.Generic;
+using System.Data;
+
+namespace WolfEventCodeCreater.StrFormat
+{
+	/// <summary>
+	/// MDファイル用の文字列整形クラス
+	/// </summary>
+	internal class MdFormat : StrFormatBase
+	{
+		/// <summary>
+		/// 見出しの文字列に整形する【MDファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <param name="headlineLevel">見出しのレベル(既定値は2)</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public override List<string> FormatHeadline(List<string> mdList , string inputStr , int headlineLevel = 2)
+		{
+			string prefixStr = "";
+
+			if (headlineLevel < 1)
+			{
+				headlineLevel = 2;
+			}
+
+			for (int i = 0; i < headlineLevel; i++)
+			{
+				prefixStr = prefixStr + "#";
+			}
+
+			mdList.Add($"{ prefixStr } { inputStr }\n");
+			return mdList;
+		}
+
+		/// <summary>
+		/// 単文の文字列に整形する【MDファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public override List<string> FormatSimpleSentence(List<string> mdList , string inputStr)
+		{
+			mdList.Add($"{ inputStr }\n");
+			return mdList;
+		}
+
+		/// <summary>
+		/// テーブル構造（ヘッダ部とデータ部とフッタ部）を作成し整形する【MDファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="headerStrs">テーブルのヘッダに適用する文字列のリスト</param>
+		/// <param name="dataStrs">テーブルのデータに適用する文字列のリスト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public override List<string> FormatTable(List<string> mdList , List<string> headerStrs , List<List<string>> dataStrs , string tableName = "")
+		{
+			if (headerStrs == null || dataStrs == null)
+			{
+				//TODO:Error処理
+				return mdList;
+			}
+
+			if ((0 < headerStrs.Count) && (0 < dataStrs.Count) && (headerStrs.Count == dataStrs[0].Count))
+			{
+				if (1 < headerStrs.Count)
+				{
+					StrTable strTable = new StrTable(headerStrs , dataStrs , "|" , "---" , tableName);
+					// System.Diagnostics.Debug.WriteLine(strTable.Columns.Count, "strTable.Columns.Count");
+					// System.Diagnostics.Debug.WriteLine(strTable.Rows.Count , "strTable.Rows.Count");
+
+					mdList = this.FormatTableHeader(mdList , strTable);
+					mdList = this.FormatTableData(mdList , strTable);
+					mdList = this.FormatTableFooter(mdList , "");
+				}
+				// headerStrsの要素が1つのみの場合は単文の文字列に整形する
+				else
+				{
+					return FormatSimpleSentence(mdList , headerStrs[0]);
+				}
+			}
+			else
+			{
+				//TODO:Error処理
+			}
+
+			return mdList;
+		}
+
+		/// <summary>
+		/// テーブルのヘッダの文字列に整形する【MDファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">文字列のテーブルオブジェクト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected override List<string> FormatTableHeader(List<string> mdList , StrTable strTable)
+		{
+			DataColumnCollection headerStrs = strTable.HeaderStrs;
+			string columnDelimiter = strTable.ColumnDelimiter;
+			string columnDelimiterStr = " " + columnDelimiter + " ";
+			string betweenHeaderAndDataDelimiter = strTable.BetweenHeaderAndDataDelimiter;
+			string headerStr = " ";
+			string headerAndDataDelimiterStr = "";
+
+			if (1 < headerStrs.Count)
+			{
+				for (int i = 0; i < headerStrs.Count - 1; i++)
+				{
+					headerStr = headerStr + headerStrs[i].ColumnName + columnDelimiterStr;
+					headerAndDataDelimiterStr = headerAndDataDelimiterStr + betweenHeaderAndDataDelimiter + columnDelimiterStr;
+				}
+				headerStr = headerStr + headerStrs[headerStrs.Count - 1].ColumnName + " ";
+				headerAndDataDelimiterStr = headerAndDataDelimiterStr + betweenHeaderAndDataDelimiter + " ";
+
+				mdList.Add(headerStr);
+				mdList.Add(headerAndDataDelimiterStr);
+			}
+			// inputStrsの要素が1つのみの場合は単文の文字列に整形する
+			else if (1 == headerStrs.Count)
+			{
+				return FormatSimpleSentence(mdList , headerStrs[0].ColumnName);
+			}
+			else
+			{
+				//TODO:Error処理
+			}
+			return mdList;
+		}
+
+		/// <summary>
+		/// テーブルのデータ部の文字列に整形する【MDファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="dataStrs">文字列のテーブルオブジェクト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected override List<string> FormatTableData(List<string> mdList , StrTable strTable)
+		{
+			DataRowCollection dataStrs = strTable.DataStrs;
+			string columnDelimiter = strTable.ColumnDelimiter;
+			string columnDelimiterStr = " " + columnDelimiter + " ";
+
+			foreach (DataRow record in dataStrs)
+			{
+				string recordStr = "";
+				foreach (var field in record.ItemArray)
+				{
+					/* field == ""の場合、WolfEventCodeCreaterのVer1.0.0.0の表記に合わせようとすると
+					recordStrの扱いが複雑になるため、
+					WolfEventCodeCreaterのVer1.0.0.0の表記に合わせないことにした。
+					ただし、MDファイルをHTML表示した時は表記の違いによる影響はない。*/
+					recordStr += field.ToString() + columnDelimiterStr;
+				}
+				recordStr = recordStr.Substring(0 , recordStr.Length - columnDelimiterStr.Length);
+				mdList.Add(recordStr);
+			}
+			return mdList;
+		}
+
+		/// <summary>
+		/// テーブルのフッタ部の文字列に整形する【MDファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected override List<string> FormatTableFooter(List<string> mdList , string inputStr)
+		{
+			mdList.Add(inputStr);
+			return mdList;
+		}
+	}
+}

--- a/StrFormat/StrFormatBase.cs
+++ b/StrFormat/StrFormatBase.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+
+namespace WolfEventCodeCreater.StrFormat
+{
+	/// <summary>
+	/// 出力ファイル用に文字列を整形するための抽象クラス
+	/// </summary>
+	public abstract class StrFormatBase
+	{
+		/// <summary>
+		/// 見出しの文字列に整形する
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <param name="headlineLevel">見出しのレベル(既定値は2)</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public abstract List<string> FormatHeadline(List<string> mdList , string inputStr , int headlineLevel = 2);
+
+		/// <summary>
+		/// 単文の文字列に整形する
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public abstract List<string> FormatSimpleSentence(List<string> mdList , string inputStr);
+
+		/// <summary>
+		/// テーブル構造（ヘッダ部とデータ部とフッタ部）を作成し整形する
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="headerStrs">テーブルのヘッダに適用する文字列のリスト</param>
+		/// <param name="dataStrs">テーブルのデータに適用する文字列のリスト</param>
+		/// <param name="tableName">テーブルの名前(既定値は"")</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public abstract List<string> FormatTable(List<string> mdList ,
+			List<string> headerStrs , List<List<string>> dataStrs , string tableName = "");
+
+		/// <summary>
+		/// テーブルのヘッダ部の文字列に整形する
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="strTable">文字列のテーブルオブジェクト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected abstract List<string> FormatTableHeader(List<string> mdList , StrTable strTable);
+
+		/// <summary>
+		/// テーブルのデータ部の文字列に整形する
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="strTable">文字列のテーブルオブジェクト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected abstract List<string> FormatTableData(List<string> mdList , StrTable strTable);
+
+		/// <summary>
+		/// テーブルのフッタ部の文字列に整形する
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected abstract List<string> FormatTableFooter(List<string> mdList , string inputStr);
+	}
+}

--- a/StrFormat/StrTable.cs
+++ b/StrFormat/StrTable.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Data;
+
+namespace WolfEventCodeCreater.StrFormat
+{
+	/// <summary>
+	/// 文字列テーブルの情報が格納されているクラス
+	/// </summary>
+	public class StrTable : DataTable
+	{
+		private string columnDelimiter;         // 列同士の区切り文字
+		private string betweenHeaderAndDataDelimiter;           // ヘッダ部とデータ部の区切り文字
+
+		private StrTable()
+		{
+		}
+
+		public StrTable(List<string> headerStrs , List<List<string>> dataStrs ,
+			string columnDelimiter , string betweenHeaderAndDataDelimiter , string tableName) : this()
+		{
+			this.TableName = tableName;
+			this.columnDelimiter = columnDelimiter;
+			this.betweenHeaderAndDataDelimiter = betweenHeaderAndDataDelimiter;
+
+			foreach (string headerStr in headerStrs)
+			{
+				this.Columns.Add(headerStr , typeof(string));
+			}
+			foreach (List<string> record in dataStrs)
+			{
+				this.Rows.Add(record.ToArray());
+			}
+		}
+
+		/// <summary>
+		/// テーブルのヘッダ部の文字列一覧
+		/// </summary>
+		public DataColumnCollection HeaderStrs { get => this.Columns; }
+
+		/// <summary>
+		/// テーブルのデータ部の文字列一覧
+		/// </summary>
+		public DataRowCollection DataStrs { get => this.Rows; }
+
+		/// <summary>
+		/// 列同士の区切り文字
+		/// </summary>
+		public string ColumnDelimiter { get => this.columnDelimiter; }
+
+		/// <summary>
+		/// ヘッダ部とデータ部の区切り文字
+		/// </summary>
+		public string BetweenHeaderAndDataDelimiter { get => this.betweenHeaderAndDataDelimiter; }
+	}
+}

--- a/StrFormat/TxtFormat.cs
+++ b/StrFormat/TxtFormat.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace WolfEventCodeCreater.StrFormat
+{
+	/// <summary>
+	/// Txtファイル用の文字列整形クラス(現在未使用)
+	/// </summary>
+	internal class TxtFormat : StrFormatBase
+	{
+		/// <summary>
+		/// 見出しの文字列に整形する【Txtファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <param name="headlineLevel">見出しのレベル(既定値は2)</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public override List<string> FormatHeadline(List<string> mdList , string inputStr , int headlineLevel = 2)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// 単文の文字列に整形する【Txtファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public override List<string> FormatSimpleSentence(List<string> mdList , string inputStr)
+		{
+			throw new NotImplementedException();
+			/* 現在は未使用
+			/// <summary>
+			/// テキスト出力用の文字列に整形する
+			/// </summary>
+			/// <param name="entryName"></param>
+			/// <param name="data"></param>
+			/// <returns></returns>
+			private string FormatOutputTxtStr(string entryName , string data)
+			{
+				return $"## { entryName } :{ data }";
+			}
+			*/
+		}
+
+		/// <summary>
+		/// テーブル構造（ヘッダ部とデータ部とフッタ部）を作成し整形する【Txtファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="headerStrs">テーブルのヘッダに適用する文字列のリスト</param>
+		/// <param name="dataStrs">テーブルのデータに適用する文字列のリスト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		public override List<string> FormatTable(List<string> mdList ,
+			List<string> headerStrs , List<List<string>> dataStrs , string tableName = "")
+		{
+			if (headerStrs == null || dataStrs == null)
+			{
+				//TODO:Error処理
+				return mdList;
+			}
+
+			if ((0 < headerStrs.Count) && (0 < dataStrs.Count) && (headerStrs.Count == dataStrs[0].Count))
+			{
+				if (1 < headerStrs.Count)
+				{
+					StrTable strTable = new StrTable(headerStrs , dataStrs , "|" , "---" , tableName);
+
+					mdList = this.FormatTableHeader(mdList , strTable);
+					mdList = this.FormatTableData(mdList , strTable);
+					mdList = this.FormatTableFooter(mdList , "");
+				}
+				// headerStrsの要素が1つのみの場合は単文の文字列に整形する
+				else
+				{
+					return FormatSimpleSentence(mdList , headerStrs[0]);
+				}
+			}
+			else
+			{
+				//TODO:Error処理
+			}
+
+			return mdList;
+		}
+
+		/// <summary>
+		/// テーブルのヘッダの文字列に整形する【Txtファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">文字列のテーブルオブジェクト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected override List<string> FormatTableHeader(List<string> mdList , StrTable strTable)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// テーブルのデータ部の文字列に整形する【Txtファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="dataStrs">文字列のテーブルオブジェクト</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected override List<string> FormatTableData(List<string> mdList , StrTable strTable)
+		{
+			throw new NotImplementedException();
+		}
+
+		/// <summary>
+		/// テーブルのフッタ部の文字列に整形する【Txtファイル】
+		/// </summary>
+		/// <param name="mdList">出力文字列が格納されたリスト</param>
+		/// <param name="inputStr">整形対象の文字列</param>
+		/// <returns>整形済みの文字列が入力された出力文字列リスト</returns>
+		protected override List<string> FormatTableFooter(List<string> mdList , string inputStr)
+		{
+			mdList.Add(inputStr);
+			return mdList;
+		}
+	}
+}

--- a/Utils/File.cs
+++ b/Utils/File.cs
@@ -47,7 +47,67 @@ namespace WolfEventCodeCreater.Utils
                 var serializer = new System.Xml.Serialization.XmlSerializer(typeof(Model.UserSetting));
                 serializer.Serialize(streamWriter, userSetting);
             }
-
         }
-    }
+
+
+
+		/// <summary>
+		/// ファイルの存在チェック
+		/// </summary>
+		/// <param name="appMesFileNameWhenNoFileExist">ファイルが存在しない場合にアプリメッセージへ追加するファイル名(""時は追加しない)</param>
+		/// <returns>ファイルが存在する場合はtrue</returns>
+		public static bool CheckFileExist(string filePath, string appMesFileNameWhenNoFileExist = "")
+		{
+			if (!Directory.Exists(filePath))
+			{
+				if(appMesFileNameWhenNoFileExist != "")
+				{
+					AppMesOpp.SetAppMessge($"{appMesFileNameWhenNoFileExist} が\r\n" +
+						$"{filePath} に見つかりません。");
+				}
+				System.Diagnostics.Debug.WriteLine($"{filePath} is No Exist.");
+				return false;
+			}
+			return true;
+		}
+
+
+
+		/// <summary>
+		/// ディレクトリの存在チェック
+		/// </summary>
+		/// <param name="appMesDirectoryNameWhenNoFileExist">ディレクトリが存在しない場合にアプリメッセージへ追加するディレクトリ名(""時は追加しない)</param>
+		/// <param name="isMakeDirectoryWhenNoFileExist">ディレクトリが存在しない場合にディレクトリを作成するか</param>
+		/// <returns>ファイルが存在する場合はtrue</returns>
+		public static bool CheckDirectoryExist(string filePath , string appMesDirectoryNameWhenNoFileExist = "" , bool isMakeDirectoryWhenNoFileExist = false)
+		{
+			if (!Directory.Exists(filePath))
+			{
+				System.Diagnostics.Debug.WriteLine($"{filePath} is No Exist.");
+
+				if (isMakeDirectoryWhenNoFileExist)
+				{
+					Directory.CreateDirectory(filePath);
+					System.Diagnostics.Debug.WriteLine($"{filePath} is created newly because of No Exist.");
+				}
+				if (appMesDirectoryNameWhenNoFileExist != "")
+				{
+					if (isMakeDirectoryWhenNoFileExist)
+					{
+						AppMesOpp.SetAppMessge($"{appMesDirectoryNameWhenNoFileExist} を\r\n" +
+						$"{filePath} に作成しました。");
+					}
+					else
+					{
+						AppMesOpp.SetAppMessge($"{appMesDirectoryNameWhenNoFileExist} が\r\n" +
+						$"{filePath} に見つかりません。");
+					}
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+	}
 }

--- a/Utils/File.cs
+++ b/Utils/File.cs
@@ -35,12 +35,31 @@ namespace WolfEventCodeCreater.Utils
 
 
 
-        /// <summary>
-        /// ユーザー設定の書き込み
-        /// </summary>
-        public static void WriteUserSetting(Model.UserSetting userSetting)
+		/// <summary>
+		/// <para>ユーザー設定の書き込み</para>
+		/// <para>パラメータ:directory="" の場合はカレントディレクトリを指定</para>
+		/// <para>パラメータ:filenameSufifxはファイル名に接尾語を追加</para>
+		/// </summary>
+		public static void WriteUserSetting(Model.UserSetting userSetting, string directory = "", string filenameSuffix = "")
         {
-            var settingFile = Path.Combine(Directory.GetCurrentDirectory(), SettingsFileName);
+			string settingFile = "";
+			string filename = SettingsFileName.Insert(SettingsFileName.Length - 4 , filenameSuffix);
+
+			if (directory == "")
+			{
+				settingFile = Path.Combine(Directory.GetCurrentDirectory() , filename);
+			}
+			else
+			{
+				if (Utils.File.CheckDirectoryExist(directory))
+				{
+					settingFile = Path.Combine(directory , filename);
+				}
+				else
+				{
+					return;
+				}
+			}
 
             using (var streamWriter = new StreamWriter(settingFile, false, new UTF8Encoding(false)))
             {

--- a/Utils/File.cs
+++ b/Utils/File.cs
@@ -62,7 +62,7 @@ namespace WolfEventCodeCreater.Utils
 			{
 				if(appMesFileNameWhenNoFileExist != "")
 				{
-					AppMesOpp.SetAppMessge($"{appMesFileNameWhenNoFileExist} が\r\n" +
+					AppMesOpp.AddAppMessge($"{appMesFileNameWhenNoFileExist} が\r\n" +
 						$"{filePath} に見つかりません。");
 				}
 				System.Diagnostics.Debug.WriteLine($"{filePath} is No Exist.");
@@ -94,12 +94,12 @@ namespace WolfEventCodeCreater.Utils
 				{
 					if (isMakeDirectoryWhenNoFileExist)
 					{
-						AppMesOpp.SetAppMessge($"{appMesDirectoryNameWhenNoFileExist} を\r\n" +
+						AppMesOpp.AddAppMessge($"{appMesDirectoryNameWhenNoFileExist} を\r\n" +
 						$"{filePath} に作成しました。");
 					}
 					else
 					{
-						AppMesOpp.SetAppMessge($"{appMesDirectoryNameWhenNoFileExist} が\r\n" +
+						AppMesOpp.AddAppMessge($"{appMesDirectoryNameWhenNoFileExist} が\r\n" +
 						$"{filePath} に見つかりません。");
 					}
 

--- a/Utils/File.cs
+++ b/Utils/File.cs
@@ -58,7 +58,7 @@ namespace WolfEventCodeCreater.Utils
 		/// <returns>ファイルが存在する場合はtrue</returns>
 		public static bool CheckFileExist(string filePath, string appMesFileNameWhenNoFileExist = "")
 		{
-			if (!Directory.Exists(filePath))
+			if (!System.IO.File.Exists(filePath))
 			{
 				if(appMesFileNameWhenNoFileExist != "")
 				{

--- a/Utils/String.cs
+++ b/Utils/String.cs
@@ -81,5 +81,16 @@ namespace WolfEventCodeCreater.Utils
 		{
 			return isOnFlag ? "On" : "Off";
 		}
+
+
+
+		//TODO:出力ファイルタイプ設定によって拡張子を変える
+		///<summary>拡張子を付与</summary>
+		/// <param name="filenamePrefix"></param>
+		/// <param name="outputFileType"></param>
+		public static string AddExtension(string filenamePrefix)
+		{
+			return filenamePrefix + ".md";
+		}
 	}
 }

--- a/Utils/String.cs
+++ b/Utils/String.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace WolfEventCodeCreater.Utils
 {
@@ -20,12 +21,46 @@ namespace WolfEventCodeCreater.Utils
 
 
 
-        /// <summary>
-        /// ファイル名に使用できない文字をフォーマットする
-        /// </summary>
-        /// <param name="filename"></param>
-        /// <returns></returns>
-        public static string FormatFilename(string filename)
+		/// <summary>
+		/// <para>二つの連続したCRコード(\r\r)を文字列から取り除く。</para>
+		/// <para>WodiKsで取得したコモンイベントコードを外部ファイル出力した際に</para>
+		/// <para>CRコードによって文字列が複数行に記述される問題を解決する。</para>
+		/// <para>※最終的に出力される文字列はウディタへ「ｸﾘｯﾌﾟﾎﾞｰﾄﾞ→ｺｰﾄﾞ貼り付け」可能となる</para>
+		/// </summary>
+		/// <param name="val"></param>
+		/// <returns></returns>
+		public static string RemoveDoubleCRCode(string val)
+		{
+			return val.Replace("\r\r","");
+		}
+
+
+
+		/// <summary>
+		/// <para>改行文字(\r\n)またはLFコード(\n)単体を&lt;\n&gt;に置換する。</para>
+		/// <para>WodiKsで取得したコモンイベントコードを外部ファイル出力した際に</para>
+		/// <para>改行文字やLFコードによって文字列が複数行に記述される問題、及び、</para>
+		/// <para>WodiKsで取得(又はクリップボードコピー)されたイベントコードが改行を意図とした改行文字やLFコードを含んでいた場合に</para>
+		/// <para>ウディタへクリップボード貼り付けできないウディタ仕様の問題を解決する。</para>
+		/// <para>※最終的に出力される文字列はウディタへ「ｸﾘｯﾌﾟﾎﾞｰﾄﾞ→ｺｰﾄﾞ貼り付け」可能となる</para>
+		/// <para>※但し、「ｲﾍﾞﾝﾄｺｰﾄﾞ→ｸﾘｯﾌﾟﾎﾞｰﾄﾞへｺﾋﾟｰ」時に実際にコピーされる文字列は&lt;\n&gt;を含んでいない</para>
+		/// </summary>
+		/// <param name="val"></param>
+		/// <returns></returns>
+		public static string EncloseCRLFCodeOrSimpleLFCodeInLtAndGt(string val)
+		{
+			val = Regex.Replace(val, "(?<![\r])\n" , "<\\n>");          // 否定的後読みの正規表現
+			return  val.Replace("\r\n" , "<\\n>");
+		}
+
+
+
+		/// <summary>
+		/// ファイル名に使用できない文字をフォーマットする
+		/// </summary>
+		/// <param name="filename"></param>
+		/// <returns></returns>
+		public static string FormatFilename(string filename)
         {
             // ファイル名に使用できない文字列を'_'に変換
             char[] invaildChars = Path.GetInvalidFileNameChars();

--- a/Utils/String.cs
+++ b/Utils/String.cs
@@ -34,5 +34,17 @@ namespace WolfEventCodeCreater.Utils
                 filename, (s, c) => s.Replace(c.ToString(), "_")
             );
         }
-    }
+
+
+
+		/// <summary>
+		/// フラグ値を文字列に変換する
+		/// </summary>
+		/// <param name="isOnFlag"></param>
+		/// <returns></returns>
+		public static string ConvertFlagToString(bool isOnFlag)
+		{
+			return isOnFlag ? "On" : "Off";
+		}
+	}
 }

--- a/Utils/String.cs
+++ b/Utils/String.cs
@@ -49,7 +49,7 @@ namespace WolfEventCodeCreater.Utils
 		/// <returns></returns>
 		public static string EncloseCRLFCodeOrSimpleLFCodeInLtAndGt(string val)
 		{
-			val = Regex.Replace(val, "(?<![\r])\n" , "<\\n>");          // 否定的後読みの正規表現
+			val = Regex.Replace(val, "(?<![\r])\n" , "<\\n>");          // 否定的後読みの正規表現。直前が\r以外の\nを置換する。
 			return  val.Replace("\r\n" , "<\\n>");
 		}
 

--- a/Utils/WodiKs.cs
+++ b/Utils/WodiKs.cs
@@ -1,4 +1,5 @@
 ﻿using WodiKs.Ev.Common;
+using WodiKs.DB;
 
 namespace WolfEventCodeCreater.Utils
 {
@@ -68,7 +69,7 @@ namespace WolfEventCodeCreater.Utils
 		/// <summary>
 		/// ComparisonMethod型を起動条件の比較方法名に変換する
 		/// </summary>
-		/// <param name="triggerConditions"></param>
+		/// <param name="comparisonMethod"></param>
 		/// <returns></returns>
 		public static string ConvertComparisonMethodToName(CommonEvent.ComparisonMethod comparisonMethod)
 		{
@@ -95,6 +96,70 @@ namespace WolfEventCodeCreater.Utils
 				case CommonEvent.ComparisonMethod.SatisfyBitOf:
 					return "とのビット積";
 
+				default:
+					return "";
+			}
+		}
+
+
+
+		/// <summary>
+		/// InputNumericData.SpecialSettingType型を数値入力の特殊設定方法名に変換する
+		/// </summary>
+		/// <param name="specialSettingType"></param>
+		/// <returns></returns>
+		public static string ConvertNumericSpecialSettingTypeToName(InputNumericData.SpecialSettingType specialSettingType)
+		{
+			switch (specialSettingType)
+			{
+				case InputNumericData.SpecialSettingType.NotUse:
+					return "特殊な設定方法を使用しない";
+				case InputNumericData.SpecialSettingType.ReferenceDatabase:
+					return "データベース参照（数値）";
+				case InputNumericData.SpecialSettingType.ManuallyGenerateBranch:
+					return "選択肢を手動作成（数値）";
+				default:
+					return "";
+			}
+		}
+
+
+
+		/// <summary>
+		/// InputStringData.SpecialSettingType型を数値入力の特殊設定方法名に変換する
+		/// </summary>
+		/// <param name="specialSettingType"></param>
+		/// <returns></returns>
+		public static string ConvertStringSpecialSettingTypeToName(InputStringData.SpecialSettingType specialSettingType)
+		{
+			switch (specialSettingType)
+			{
+				case InputStringData.SpecialSettingType.NotUse:
+					return "特殊な設定方法を使用しない";
+				default:
+					return "";
+			}
+		}
+
+
+
+		/// <summary>
+		/// DatabaseCategory型をデータベースの種類名に変換する
+		/// </summary>
+		/// <param name="triggerConditions"></param>
+		/// <returns></returns>
+		public static string ConvertDatabaseCategoryToName(Database.DatabaseCategory dbCategory)
+		{
+			switch (dbCategory)
+			{
+				case Database.DatabaseCategory.Changeable:
+					return "可変データベース";
+				case Database.DatabaseCategory.User:
+					return "ユーザーデータベース";
+				case Database.DatabaseCategory.System:
+					return "システムデータベース";
+				case Database.DatabaseCategory.CommonEvent:
+					return "コモンイベント";
 				default:
 					return "";
 			}

--- a/Utils/WodiKs.cs
+++ b/Utils/WodiKs.cs
@@ -1,0 +1,103 @@
+﻿using WodiKs.Ev.Common;
+
+namespace WolfEventCodeCreater.Utils
+{
+	public static class WodiKs
+	{
+		/// <summary>
+		/// CommonEventColor型を色名に変換する
+		/// </summary>
+		/// <param name="commonEventColor"></param>
+		/// <returns></returns>
+		public static string ConvertCommonEventColorToName(CommonEvent.CommonEventColor commonEventColor)
+		{
+			switch (commonEventColor)
+			{
+				case CommonEvent.CommonEventColor.Black:
+					return "黒";
+
+				case CommonEvent.CommonEventColor.Red:
+					return "赤色";
+
+				case CommonEvent.CommonEventColor.Blue:
+					return "青色";
+
+				case CommonEvent.CommonEventColor.Green:
+					return "緑色";
+
+				case CommonEvent.CommonEventColor.Purple:
+					return "紫色";
+
+				case CommonEvent.CommonEventColor.Yellow:
+					return "黄色";
+
+				case CommonEvent.CommonEventColor.Gray:
+					return "グレー";
+
+				default:
+					return "";
+			}
+		}
+
+		/// <summary>
+		/// TriggerConditions型を起動条件名に変換する
+		/// </summary>
+		/// <param name="triggerConditions"></param>
+		/// <returns></returns>
+		public static string ConvertTriggerConditionsToName(CommonEvent.TriggerConditions triggerConditions)
+		{
+			switch (triggerConditions)
+			{
+				case CommonEvent.TriggerConditions.OnlyCall:
+					return "呼び出しのみ";
+
+				case CommonEvent.TriggerConditions.Automatic:
+					return "自動実行";
+
+				case CommonEvent.TriggerConditions.Parallel:
+					return "並列実行";
+
+				case CommonEvent.TriggerConditions.ParallelAlways:
+					return "並列実行(常時)";
+
+				default:
+					return "";
+			}
+		}
+
+		/// <summary>
+		/// ComparisonMethod型を起動条件の比較方法名に変換する
+		/// </summary>
+		/// <param name="triggerConditions"></param>
+		/// <returns></returns>
+		public static string ConvertComparisonMethodToName(CommonEvent.ComparisonMethod comparisonMethod)
+		{
+			switch (comparisonMethod)
+			{
+				case CommonEvent.ComparisonMethod.Greater:
+					return "より大きい";
+
+				case CommonEvent.ComparisonMethod.GreaterOrEqual:
+					return "以上";
+
+				case CommonEvent.ComparisonMethod.Same:
+					return "と同じ";
+
+				case CommonEvent.ComparisonMethod.Less:
+					return "未満";
+
+				case CommonEvent.ComparisonMethod.LessOrEqual:
+					return "以下";
+
+				case CommonEvent.ComparisonMethod.Not:
+					return "以外";
+
+				case CommonEvent.ComparisonMethod.SatisfyBitOf:
+					return "とのビット積";
+
+				default:
+					return "";
+			}
+		}
+	}
+}

--- a/Utils/WodiKs.cs
+++ b/Utils/WodiKs.cs
@@ -146,7 +146,7 @@ namespace WolfEventCodeCreater.Utils
 		/// <summary>
 		/// DatabaseCategory型をデータベースの種類名に変換する
 		/// </summary>
-		/// <param name="triggerConditions"></param>
+		/// <param name="dbCategory"></param>
 		/// <returns></returns>
 		public static string ConvertDatabaseCategoryToName(Database.DatabaseCategory dbCategory)
 		{
@@ -164,5 +164,74 @@ namespace WolfEventCodeCreater.Utils
 					return "";
 			}
 		}
+
+
+
+		/// <summary>
+		/// SettingType型をデータIDの設定方法名に変換する
+		/// </summary>
+		/// <param name="settingType"></param>
+		/// <returns></returns>
+		public static string ConvertSettingTypeToName(TypeConfig.SettingType settingType)
+		{
+			switch (settingType)
+			{
+				case TypeConfig.SettingType.Manuall:
+					return "手動で設定";
+				case TypeConfig.SettingType.FirstStringData:
+					return "最初の文字列データ";
+				case TypeConfig.SettingType.PreviousTypeData:
+					return "1つ前のタイプのデータID";
+				case TypeConfig.SettingType.DesiredDBType:
+					return "指定DBの指定タイプから";
+				default:
+					return "";
+			}
+		}
+
+
+
+		/// <summary>
+		/// ItemConfig.SpecialSettingType型を項目の特殊設定方法名に変換する
+		/// </summary>
+		/// <param name="specialSettingType"></param>
+		/// <returns></returns>
+		public static string ConvertItemConfigSpecialSettingTypeToName(ItemConfig.SpecialSettingType specialSettingType)
+		{
+			switch (specialSettingType)
+			{
+				case ItemConfig.SpecialSettingType.NotUse:
+					return "特殊な設定方法を使用しない";
+				case ItemConfig.SpecialSettingType.ReadFile:
+					return "ファイル読み込み（文字列）";
+				case ItemConfig.SpecialSettingType.ReferenceDatabase:
+					return "データベース参照（数値）";
+				case ItemConfig.SpecialSettingType.ManuallyGenerateBranch:
+					return "選択肢を手動作成（数値）";
+				default:
+					return "";
+			}
+		}
+
+
+
+		/// <summary>
+		/// ItemConfig.ItemType型を項目内容のタイプ名に変換する
+		/// </summary>
+		/// <param name="itemType"></param>
+		/// <returns></returns>
+		public static string ConvertItemTypeToName(ItemConfig.ItemType itemType)
+		{
+			switch (itemType)
+			{
+				case ItemConfig.ItemType.Numeric:
+					return "数値";
+				case ItemConfig.ItemType.String:
+					return "文字列";
+				default:
+					return "";
+			}
+		}
+
 	}
 }

--- a/WolfEventCodeCreater.csproj
+++ b/WolfEventCodeCreater.csproj
@@ -63,7 +63,8 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="WodiKs">
-      <HintPath>..\..\..\..\Downloads\WodiKs-Ver0.40[α版]\WodiKs.dll</HintPath>
+      <HintPath>.\WodiKs.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -86,6 +87,7 @@
     <Compile Include="Model\UserSetting.cs" />
     <Compile Include="Utils\File.cs" />
     <Compile Include="Utils\String.cs" />
+    <Compile Include="Utils\WodiKs.cs" />
     <EmbeddedResource Include="MainWindow.resx">
       <DependentUpon>MainWindow.cs</DependentUpon>
     </EmbeddedResource>
@@ -138,6 +140,7 @@ del /q *dll
 del /q tmp.exe</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent>del /q *.*</PreBuildEvent>
+    <PreBuildEvent>del /q *.*
+copy /y ..\..\*.dll %25CD%25</PreBuildEvent>
   </PropertyGroup>
 </Project>

--- a/WolfEventCodeCreater.csproj
+++ b/WolfEventCodeCreater.csproj
@@ -69,13 +69,25 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeCreater.cs" />
-    <Compile Include="ErrorOperation.cs" />
+    <Compile Include="AppMesOpp.cs" />
     <Compile Include="MainWindow.cs">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="MainWindow.Designer.cs">
       <DependentUpon>MainWindow.cs</DependentUpon>
     </Compile>
+    <Compile Include="Model\OutputDriver.cs" />
+    <Compile Include="Model\OutputStruct\OutputStructBase.cs" />
+    <Compile Include="Model\OutputStruct\OutputStructMix.cs" />
+    <Compile Include="Model\OutputStruct\OutputStructSentence.cs" />
+    <Compile Include="Model\OutputStruct\OutputStructTable.cs" />
+    <Compile Include="Model\OutputStruct\OutputStructTables.cs" />
+    <Compile Include="Model\WoditerStr\DatabaseItemConfigStr.cs" />
+    <Compile Include="Model\WoditerStr\DatabaseItemStr.cs" />
+    <Compile Include="Model\WoditerStr\DatabaseTypeStr.cs" />
+    <Compile Include="Model\WoditerStr\DatabaseDataIDStr.cs" />
+    <Compile Include="Model\WoditerInfo.cs" />
+    <Compile Include="Model\WoditerStr\WoditerInfoStr.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Model\Config.cs" />

--- a/WolfEventCodeCreater.csproj
+++ b/WolfEventCodeCreater.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeCreater.cs" />
+    <Compile Include="ErrorOperation.cs" />
     <Compile Include="MainWindow.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -85,6 +86,12 @@
       <DependentUpon>SettingWindow.cs</DependentUpon>
     </Compile>
     <Compile Include="Model\UserSetting.cs" />
+    <Compile Include="StrFormat\MdFormat.cs" />
+    <Compile Include="StrFormat\StrFormatBase.cs" />
+    <Compile Include="StrFormat\StrTable.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="StrFormat\TxtFormat.cs" />
     <Compile Include="Utils\File.cs" />
     <Compile Include="Utils\String.cs" />
     <Compile Include="Utils\WodiKs.cs" />

--- a/WolfEventCodeCreater.csproj
+++ b/WolfEventCodeCreater.csproj
@@ -77,11 +77,9 @@
       <DependentUpon>MainWindow.cs</DependentUpon>
     </Compile>
     <Compile Include="Model\OutputDriver.cs" />
-    <Compile Include="Model\OutputStruct\OutputStructBase.cs" />
-    <Compile Include="Model\OutputStruct\OutputStructMix.cs" />
     <Compile Include="Model\OutputStruct\OutputStructSentence.cs" />
+    <Compile Include="Model\OutputStruct\OutputStructBase.cs" />
     <Compile Include="Model\OutputStruct\OutputStructTable.cs" />
-    <Compile Include="Model\OutputStruct\OutputStructTables.cs" />
     <Compile Include="Model\WoditerStr\DatabaseItemConfigStr.cs" />
     <Compile Include="Model\WoditerStr\DatabaseItemStr.cs" />
     <Compile Include="Model\WoditerStr\DatabaseTypeStr.cs" />


### PR DESCRIPTION
#### ファイル出力内容が大幅に変わったので、一応メジャーバージョンアップ(ver2.0.0)としていますが、お任せします。

### 変更点

**1. 以下のコモンイベント情報をさらに取得可能**
- コモンイベント番号
- コモンイベント色
- 起動条件
- 引数（WodiKs.dllのバグにより、手動設定した選択肢の内部値は取得不可）
- 返り値
- コモンセルフ変数
- 動作指定コマンドコード

**2. 以下の設定機能を有効化**
- 出力先フォルダ
- 出力しないコモンのコメントアウト設定
- コモンイベント番号をファイルに付けるか（出力する場合、ファイル名の先頭に番号を付与）

**3. DB情報の取得機能を実装（仕掛り）**
WodiKs.dllのDB読込バグにより、一旦実装を中止中（中途半端で申し訳ないです。別ブランチでやるべきでした）

**4. その他**
- アプリ起動時に直近で出力したルートパスを再読込可能（setting.xmlにパスを書き込み）
- ルートパスをテキストボックスに直入力しても反映されなかったバグを修正
- 入力またはフォルダ参照したルートパスが有効か（ウディタの定義情報ファイルが含まるか）を自動判定
- setting.xmlをファイル出力先のフォルダにも作成するよう変更（出力時の設定を保管できるようにするため）
- その他、細かな内部処理の実装を変更

### 今後の予定
- DB取得の実装
    　⇒WodiKs.dllの作者様より非公開のver0.75を提供していただいたので、今後テスト予定
- 設定可能な項目の多様化
- 既存のコモンイベント情報の取得と出力処理をOutputDriverクラス配下で制御